### PR TITLE
Feat/allow spaces

### DIFF
--- a/internal/pkg/values/layer.go
+++ b/internal/pkg/values/layer.go
@@ -11,7 +11,7 @@ var (
 	errUpAndDownTime            = errors.New("error: both uptime and downtime are defined")
 	errTimeAndPeriod            = errors.New("error: both a time and a period is defined")
 	errInvalidDownscaleReplicas = errors.New("error: downscale replicas value is invalid")
-	errValueNotSet              = errors.New("error: value isn't set")
+	errValueNotSet              = errors.New("error: no layer implements this value")
 )
 
 const Undefined = -1 // Undefined represents an undefined integer value

--- a/internal/pkg/values/stringlist.go
+++ b/internal/pkg/values/stringlist.go
@@ -9,10 +9,12 @@ import (
 type StringList []string
 
 func (s *StringList) Set(text string) error {
-	values := strings.Split(text, ",")
-	for _, value := range values {
-		*s = append(*s, strings.TrimSpace(value))
+	entries := strings.Split(text, ",")
+	var trimmedEntries []string
+	for _, entry := range entries {
+		trimmedEntries = append(trimmedEntries, strings.TrimSpace(entry))
 	}
+	*s = trimmedEntries
 	return nil
 }
 

--- a/internal/pkg/values/stringlist.go
+++ b/internal/pkg/values/stringlist.go
@@ -8,8 +8,11 @@ import (
 // StringList is an alias for []string with a Set funciton for the flag package
 type StringList []string
 
-func (s *StringList) Set(value string) error {
-	*s = strings.Split(value, ",")
+func (s *StringList) Set(text string) error {
+	values := strings.Split(text, ",")
+	for _, value := range values {
+		*s = append(*s, strings.TrimSpace(value))
+	}
 	return nil
 }
 

--- a/internal/pkg/values/timespan.go
+++ b/internal/pkg/values/timespan.go
@@ -176,7 +176,7 @@ func (t absoluteTimeSpan) isTimeInSpan(targetTime time.Time) bool {
 
 // isAbsoluteTimestamp checks if timestamp string is absolute
 func isAbsoluteTimestamp(timestamp string) bool {
-	return absoluteTimeSpanRegex.Match([]byte(timestamp))
+	return absoluteTimeSpanRegex.MatchString(timestamp)
 }
 
 // getWeekday gets the weekday from the given string

--- a/internal/pkg/values/timespan.go
+++ b/internal/pkg/values/timespan.go
@@ -11,6 +11,7 @@ import (
 
 var errInvalidWeekday = errors.New("error: specified weekday is invalid")
 var errRelativeTimespanInvalid = errors.New("error: specified relative timespan is invalid")
+var errTimeOfDayOutOfRange = errors.New("error: the time of day has fields that are out of rane")
 
 // rfc339Regex is a regex that matches an rfc339 timestamp
 const rfc3339Regex = `(.+Z|.+[+-]\d{2}:\d{2})`
@@ -204,9 +205,15 @@ func parseDayTime(daytime string, timezone *time.Location) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to parse hour of daytime: %w", err)
 	}
+	if hour < 0 || hour > 24 {
+		return time.Time{}, errTimeOfDayOutOfRange
+	}
 	minute, err := strconv.Atoi(parts[1])
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to parse minute of daytime: %w", err)
+	}
+	if minute < 0 || minute >= 60 {
+		return time.Time{}, errTimeOfDayOutOfRange
 	}
 	return time.Date(0, time.January, 1, hour, minute, 0, 0, timezone), nil
 }

--- a/internal/pkg/values/timespan.go
+++ b/internal/pkg/values/timespan.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -108,14 +109,16 @@ func parseRelativeTimeSpan(timespanString string) (*relativeTimeSpan, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse timezone: %w", err)
 	}
-	timespan.timeFrom, err = time.ParseInLocation("15:04", timeSpan[0], timespan.timezone)
+
+	timespan.timeFrom, err = parseDayTime(timeSpan[0], timespan.timezone)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse 'timeFrom': %w", err)
+		return nil, fmt.Errorf("failed to parse time of day from: %w", err)
 	}
-	timespan.timeTo, err = time.ParseInLocation("15:04", timeSpan[1], timespan.timezone)
+	timespan.timeTo, err = parseDayTime(timeSpan[1], timespan.timezone)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse 'timeTo': %w", err)
+		return nil, fmt.Errorf("failed to parse time of day to: %w", err)
 	}
+
 	timespan.weekdayFrom, err = getWeekday(weekdaySpan[0])
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse 'weekdayFrom': %w", err)
@@ -192,6 +195,20 @@ func getWeekday(weekday string) (time.Weekday, error) {
 	}
 
 	return 0, errInvalidWeekday
+}
+
+// parseDayTime parses the given time of day string to a zero date time
+func parseDayTime(daytime string, timezone *time.Location) (time.Time, error) {
+	parts := strings.Split(daytime, ":")
+	hour, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse hour of daytime: %w", err)
+	}
+	minute, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse minute of daytime: %w", err)
+	}
+	return time.Date(0, time.January, 1, hour, minute, 0, 0, timezone), nil
 }
 
 // getTimeOfDay gets the time of day of the given time

--- a/internal/pkg/values/timespan_test.go
+++ b/internal/pkg/values/timespan_test.go
@@ -48,8 +48,20 @@ func TestParseRelativeTimeSpan(t *testing.T) {
 			wantErr:        true,
 		},
 		{
-			name:           "invalid Time",
+			name:           "invalid Format",
 			timespanString: "Mon-Fri 03:00-04-00 UTC",
+			wantResult:     nil,
+			wantErr:        true,
+		},
+		{
+			name:           "negative Time",
+			timespanString: "Mon-Fri -03:00-04:00 UTC",
+			wantResult:     nil,
+			wantErr:        true,
+		},
+		{
+			name:           "out of range Time",
+			timespanString: "Mon-Fri 00:00-26:00 UTC",
 			wantResult:     nil,
 			wantErr:        true,
 		},
@@ -193,6 +205,18 @@ func TestRelativeTimeSpan_isTimeOfDayInRange(t *testing.T) {
 			timespan:   relativeTimeSpan{timeFrom: zeroTime, timeTo: zeroTime.Add(24 * time.Hour)},
 			timeOfDay:  zeroTime,
 			wantResult: true,
+		},
+		{
+			name:       "all day reverse",
+			timespan:   relativeTimeSpan{timeFrom: zeroTime.Add(24 * time.Hour), timeTo: zeroTime},
+			timeOfDay:  zeroTime.Add(18 * time.Hour),
+			wantResult: false,
+		},
+		{
+			name:       "never",
+			timespan:   relativeTimeSpan{timeFrom: zeroTime, timeTo: zeroTime},
+			timeOfDay:  zeroTime,
+			wantResult: false,
 		},
 	}
 

--- a/internal/pkg/values/timespan_test.go
+++ b/internal/pkg/values/timespan_test.go
@@ -207,13 +207,25 @@ func TestRelativeTimeSpan_isTimeOfDayInRange(t *testing.T) {
 			wantResult: true,
 		},
 		{
-			name:       "all day reverse",
+			name:       "24 never",
 			timespan:   relativeTimeSpan{timeFrom: zeroTime.Add(24 * time.Hour), timeTo: zeroTime},
 			timeOfDay:  zeroTime.Add(18 * time.Hour),
 			wantResult: false,
 		},
 		{
-			name:       "never",
+			name:       "24 never overlap to next day",
+			timespan:   relativeTimeSpan{timeFrom: zeroTime.Add(24 * time.Hour), timeTo: zeroTime},
+			timeOfDay:  zeroTime.Add(24*time.Hour - time.Nanosecond),
+			wantResult: false,
+		},
+		{
+			name:       "24 never start of day",
+			timespan:   relativeTimeSpan{timeFrom: zeroTime.Add(24 * time.Hour), timeTo: zeroTime},
+			timeOfDay:  zeroTime,
+			wantResult: false,
+		},
+		{
+			name:       "0 never",
 			timespan:   relativeTimeSpan{timeFrom: zeroTime, timeTo: zeroTime},
 			timeOfDay:  zeroTime,
 			wantResult: false,

--- a/internal/pkg/values/timespan_test.go
+++ b/internal/pkg/values/timespan_test.go
@@ -49,9 +49,21 @@ func TestParseRelativeTimeSpan(t *testing.T) {
 		},
 		{
 			name:           "invalid Time",
-			timespanString: "Mon-Fri 03:00-04:0 UTC",
+			timespanString: "Mon-Fri 03:00-04-00 UTC",
 			wantResult:     nil,
 			wantErr:        true,
+		},
+		{
+			name:           "all day",
+			timespanString: "Mon-Fri 00:00-24:00 UTC",
+			wantResult: &relativeTimeSpan{
+				timezone:    time.UTC,
+				weekdayFrom: time.Monday,
+				weekdayTo:   time.Friday,
+				timeFrom:    zeroTime,
+				timeTo:      zeroTime.Add(24 * time.Hour),
+			},
+			wantErr: false,
 		},
 	}
 
@@ -162,6 +174,24 @@ func TestRelativeTimeSpan_isTimeOfDayInRange(t *testing.T) {
 			name:       "reverse from in range",
 			timespan:   relativeTimeSpan{timeFrom: zeroTime.Add(18 * time.Hour), timeTo: zeroTime.Add(4 * time.Hour)},
 			timeOfDay:  zeroTime.Add(18 * time.Hour),
+			wantResult: true,
+		},
+		{
+			name:       "all day",
+			timespan:   relativeTimeSpan{timeFrom: zeroTime, timeTo: zeroTime.Add(24 * time.Hour)},
+			timeOfDay:  zeroTime.Add(18 * time.Hour),
+			wantResult: true,
+		},
+		{
+			name:       "all day overlap to next day",
+			timespan:   relativeTimeSpan{timeFrom: zeroTime, timeTo: zeroTime.Add(24 * time.Hour)},
+			timeOfDay:  zeroTime.Add(24*time.Hour - time.Nanosecond),
+			wantResult: true,
+		},
+		{
+			name:       "all day start of day",
+			timespan:   relativeTimeSpan{timeFrom: zeroTime, timeTo: zeroTime.Add(24 * time.Hour)},
+			timeOfDay:  zeroTime,
 			wantResult: true,
 		},
 	}

--- a/internal/pkg/values/timespan_test.go
+++ b/internal/pkg/values/timespan_test.go
@@ -320,7 +320,7 @@ func TestAbsoluteTimeSpan_isTimeInSpan(t *testing.T) {
 }
 
 func TestParseAbsoluteTimeSpan(t *testing.T) {
-	time1 := time.Now().Truncate(time.Second)
+	time1 := time.Date(2024, time.February, 27, 0, 0, 0, 0, time.UTC)
 	time2 := time1.Add(48 * time.Hour)
 
 	tests := []struct {
@@ -369,7 +369,7 @@ func TestParseAbsoluteTimeSpan(t *testing.T) {
 }
 
 func TestIsAbsoluteTimestamp(t *testing.T) {
-	time1 := time.Now().Truncate(time.Second)
+	time1 := time.Date(2024, time.February, 27, 0, 0, 0, 0, time.UTC)
 	time2 := time1.Add(48 * time.Hour)
 
 	tests := []struct {


### PR DESCRIPTION
## Motivation

Closes #24 

## Changes

Implemented trimming spaces in:
- absolute timespans: implemented as [this comment](https://github.com/caas-team/GoKubeDownscaler/issues/24#issuecomment-2287158160) stated, using regex
- stringlist: trims the spaces from each entry
explicitly not implemented in:
- Duration
- triStateBool

## Tests done

- [X] unit tests passed

## TODO

- [x] I've assigned myself to this PR
