### PR TITLE
Automatically Assign PR Author if No Assignee is Set

### DIFF
--- a/.github/workflows/auto-assign-pr-author.yaml
+++ b/.github/workflows/auto-assign-pr-author.yaml
@@ -8,7 +8,7 @@ jobs:
   auto-assign:
     runs-on: ubuntu-latest
     steps:
-      - name: Check if assignee exists
+      - name: Check If Assignee Exists
         uses: actions/github-script@v6
         id: check-assignee
         with:
@@ -16,7 +16,7 @@ jobs:
             const assignees = context.payload.pull_request.assignees;
             return assignees.length > 0;
 
-      - name: Assign PR author if no assignee
+      - name: Assign PR Author If No Assignee
         if: steps.check-assignee.outputs.result == 'false'
         uses: actions-ecosystem/action-add-assignees@v1
         with:

--- a/.github/workflows/auto-assign-pr-author.yaml
+++ b/.github/workflows/auto-assign-pr-author.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   auto-assign:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-assign-pr-author.yaml
+++ b/.github/workflows/auto-assign-pr-author.yaml
@@ -1,0 +1,24 @@
+name: Auto Assign PR Author
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if assignee exists
+        uses: actions/github-script@v6
+        id: check-assignee
+        with:
+          script: |
+            const assignees = context.payload.pull_request.assignees;
+            return assignees.length > 0;
+
+      - name: Assign PR author if no assignee
+        if: steps.check-assignee.outputs.result == 'false'
+        uses: actions-ecosystem/action-add-assignees@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
## Motivation

This change aims to automate the process of assigning the author to a pull request when no other assignee is set. It helps prevent the issue of forgotten or missing PR assignments, ensuring that the PR always has someone responsible.

- Closes https://github.com/caas-team/GoKubeDownscaler/issues/46

## Changes

- Added a GitHub Actions workflow that checks if a pull request has an assignee.
- Automatically assigns the PR author if no assignee is present.

## Tests done

- Tested the workflow locally by opening and reopening pull requests with and without existing assignees.

## TODO

- [x] I've assigned myself to this PR