### PR TITLE
fix: let workflow not trigger on labels

### DIFF
--- a/.github/workflows/check-for-release.yaml
+++ b/.github/workflows/check-for-release.yaml
@@ -38,11 +38,14 @@ jobs:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'new release') }}
         run: |
           if [ "${{ env.app_version_change }}" == "version changed" ]; then
+            gh pr edit ${{ github.event.pull_request.number }} --add-label "needs approval"
             echo "Version changed, exiting..."
             exit 1
           else
             echo "No appVersion changes detected."
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Remove approval label
         run: |
@@ -77,9 +80,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: "⚠️ Warning: Merging this PR will result in a new release because the `appVersion` in Chart.yaml has changed to `${{ env.appversion }}`. Please confirm this by adding the `new release` label before merging."
-
-      - name: Set a label on the pull request
-        run: |
-          gh pr edit ${{ github.event.pull_request.number }} --add-label "needs approval"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-for-release.yaml
+++ b/.github/workflows/check-for-release.yaml
@@ -54,7 +54,7 @@ jobs:
     name: Post Message To Warn Of New Release
     runs-on: ubuntu-latest
     needs: check_for_release
-    if: ${{ failure() && !contains(github.event.pull_request.labels.*.name, 'needs approval') }}
+    if: ${{ failure() && !contains(github.event.pull_request.labels.*.name, 'needs approval') && github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Motivation
The check for release workflow triggered the warning message multiple times when you created labels beforehand.
<!--
Explain briefly what this change aims to achieve and why it is important to do so.
Please keep this description updated with any discussion that takes place so
that reviewers can understand your intent. Keeping the description updated is
especially important if they didn't participate in the discussion.
-->

## Changes
Changed the if check for the job.
<!--
List the changes made to the code base. Per default, all commits are listed here.
Please keep this description updated as you add new changes to the PR.
-->
## Tests done

I tested this [here](https://github.com/JTaeuber/test-chart/pull/34).
Now it always adds the `needs approval` label if it was removed without writing the message again for labeling and unlabeling.