### PR TITLE
Feat/exclude workloads managed by scaled object

### DIFF
--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -97,6 +97,7 @@ func main() {
 		slog.Error("found incompatible fields", "error", err)
 		os.Exit(1)
 	}
+	includeResources = values.OrderIncludeResourcesArgument(includeResources)
 	ctx := context.Background()
 
 	slog.Debug("getting client for kubernetes")
@@ -109,7 +110,6 @@ func main() {
 	slog.Info("started downscaler")
 	for {
 		slog.Info("scanning workloads")
-
 		workloads, err := client.GetWorkloads(includeNamespaces, includeResources, ctx)
 		if err != nil {
 			slog.Error("failed to get workloads", "error", err)

--- a/internal/pkg/scalable/cronjobs.go
+++ b/internal/pkg/scalable/cronjobs.go
@@ -4,9 +4,18 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	batch "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// GVK for cronJobs
+var cronJobGVK = schema.GroupVersionKind{
+	Group:   "batch",
+	Version: "v1",
+	Kind:    "CronJob",
+}
 
 // getCronJobs is the getResourceFunc for CronJobs
 func getCronJobs(namespace string, clientsets *Clientsets, ctx context.Context) ([]Workload, error) {
@@ -24,6 +33,16 @@ func getCronJobs(namespace string, clientsets *Clientsets, ctx context.Context) 
 // cronJob is a wrapper for batch/v1.CronJob to implement the suspendScaledResource interface
 type cronJob struct {
 	*batch.CronJob
+}
+
+// GetObjectKind sets the GVK for cronJob
+func (c *cronJob) GetObjectKind() schema.ObjectKind {
+	return c
+}
+
+// GroupVersionKind returns the GVK for cronJob
+func (c *cronJob) GroupVersionKind() schema.GroupVersionKind {
+	return cronJobGVK
 }
 
 // setSuspend sets the value of the suspend field on the cronJob

--- a/internal/pkg/scalable/daemonsets.go
+++ b/internal/pkg/scalable/daemonsets.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -11,6 +13,13 @@ import (
 const (
 	labelMatchNone = "downscaler/match-none"
 )
+
+// GVK for daemonSets
+var daemonSetGVK = schema.GroupVersionKind{
+	Group:   "apps",
+	Version: "v1",
+	Kind:    "DaemonSet",
+}
 
 // getDaemonSets is the getResourceFunc for DaemonSets
 func getDaemonSets(namespace string, clientsets *Clientsets, ctx context.Context) ([]Workload, error) {
@@ -28,6 +37,16 @@ func getDaemonSets(namespace string, clientsets *Clientsets, ctx context.Context
 // daemonSet is a wrapper for apps/v1.DeamonSet to implement the Workload interface
 type daemonSet struct {
 	*appsv1.DaemonSet
+}
+
+// GetObjectKind sets the GVK for daemonSet
+func (d *daemonSet) GetObjectKind() schema.ObjectKind {
+	return d
+}
+
+// GroupVersionKind returns the GVK for daemonSet
+func (d *daemonSet) GroupVersionKind() schema.GroupVersionKind {
+	return daemonSetGVK
 }
 
 // ScaleUp scales the resource up

--- a/internal/pkg/scalable/deployments.go
+++ b/internal/pkg/scalable/deployments.go
@@ -4,9 +4,18 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// Define the GVK for deployments
+var deploymentGVK = schema.GroupVersionKind{
+	Group:   "apps",
+	Version: "v1",
+	Kind:    "Deployment",
+}
 
 // getDeployments is the getResourceFunc for Deployments
 func getDeployments(namespace string, clientsets *Clientsets, ctx context.Context) ([]Workload, error) {
@@ -24,6 +33,16 @@ func getDeployments(namespace string, clientsets *Clientsets, ctx context.Contex
 // deployment is a wrapper for apps/v1.Deployment to implement the replicaScaledResource interface
 type deployment struct {
 	*appsv1.Deployment
+}
+
+// GetObjectKind implements the scalableResource interface and sets the GVK
+func (d *deployment) GetObjectKind() schema.ObjectKind {
+	return d
+}
+
+// GroupVersionKind returns the GVK for deployments
+func (d *deployment) GroupVersionKind() schema.GroupVersionKind {
+	return deploymentGVK
 }
 
 // setReplicas sets the amount of replicas on the resource. Changes won't be made on Kubernetes until update() is called

--- a/internal/pkg/scalable/horizontalpodautoscalers.go
+++ b/internal/pkg/scalable/horizontalpodautoscalers.go
@@ -5,11 +5,20 @@ import (
 	"errors"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	appsv1 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var errMinReplicasBoundsExceeded = errors.New("error: a HPAs minReplicas can only be set to int32 values larger than 1")
+
+// Define the GVK for horizontalPodAutoscalers
+var horizontalPodAutoscalerGVK = schema.GroupVersionKind{
+	Group:   "autoscaling",
+	Version: "v2",
+	Kind:    "HorizontalPodAutoscaler",
+}
 
 // getHorizontalPodAutoscalers is the getResourceFunc for horizontalPodAutoscalers
 func getHorizontalPodAutoscalers(namespace string, clientsets *Clientsets, ctx context.Context) ([]Workload, error) {
@@ -27,6 +36,16 @@ func getHorizontalPodAutoscalers(namespace string, clientsets *Clientsets, ctx c
 // horizontalPodAutoscaler is a wrapper for autoscaling/v2.HorizontalPodAutoscaler to implement the replicaScaledResource interface
 type horizontalPodAutoscaler struct {
 	*appsv1.HorizontalPodAutoscaler
+}
+
+// GetObjectKind sets the GVK for horizontalPodAutoscaler
+func (h *horizontalPodAutoscaler) GetObjectKind() schema.ObjectKind {
+	return h
+}
+
+// GroupVersionKind returns the GVK for horizontalPodAutoscaler
+func (h *horizontalPodAutoscaler) GroupVersionKind() schema.GroupVersionKind {
+	return horizontalPodAutoscalerGVK
 }
 
 // setReplicas sets the amount of replicas on the resource. Changes won't be made on Kubernetes until update() is called

--- a/internal/pkg/scalable/jobs.go
+++ b/internal/pkg/scalable/jobs.go
@@ -4,9 +4,18 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	batch "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// GVK for jobs
+var jobGVK = schema.GroupVersionKind{
+	Group:   "batch",
+	Version: "v1",
+	Kind:    "Job",
+}
 
 // getDeployments is the getResourceFunc for Jobs
 func getJobs(namespace string, clientsets *Clientsets, ctx context.Context) ([]Workload, error) {
@@ -26,9 +35,19 @@ type job struct {
 	*batch.Job
 }
 
+// GetObjectKind sets the GVK for jobs
+func (j *job) GetObjectKind() schema.ObjectKind {
+	return j
+}
+
+// GroupVersionKind returns the GVK for jobs
+func (j *job) GroupVersionKind() schema.GroupVersionKind {
+	return jobGVK
+}
+
 // setSuspend sets the value of the suspend field on the job
-func (c *job) setSuspend(suspend bool) {
-	c.Spec.Suspend = &suspend
+func (j *job) setSuspend(suspend bool) {
+	j.Spec.Suspend = &suspend
 }
 
 // Update updates the resource with all changes made to it. It should only be called once on a resource

--- a/internal/pkg/scalable/poddisruptionbudgets.go
+++ b/internal/pkg/scalable/poddisruptionbudgets.go
@@ -5,12 +5,21 @@ import (
 	"fmt"
 	"log/slog"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/caas-team/gokubedownscaler/internal/pkg/values"
 
 	policy "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
+
+// Define the GVK for podDisruptionBudget
+var podDisruptionBudgetGVK = schema.GroupVersionKind{
+	Group:   "policy",
+	Version: "v1",
+	Kind:    "PodDisruptionBudget",
+}
 
 // getPodDisruptionBudgets is the getResourceFunc for podDisruptionBudget
 func getPodDisruptionBudgets(namespace string, clientsets *Clientsets, ctx context.Context) ([]Workload, error) {
@@ -28,6 +37,16 @@ func getPodDisruptionBudgets(namespace string, clientsets *Clientsets, ctx conte
 // podDisruptionBudget is a wrapper for policy/v1.PodDisruptionBudget to implement the Workload interface
 type podDisruptionBudget struct {
 	*policy.PodDisruptionBudget
+}
+
+// GetObjectKind sets the GVK for podDisruptionBudget
+func (p *podDisruptionBudget) GetObjectKind() schema.ObjectKind {
+	return p
+}
+
+// GroupVersionKind returns the GVK for podDisruptionBudget
+func (p *podDisruptionBudget) GroupVersionKind() schema.GroupVersionKind {
+	return podDisruptionBudgetGVK
 }
 
 // getMinAvailableInt returns the spec.MinAvailable value if it is not a percentage

--- a/internal/pkg/scalable/scaledobjects.go
+++ b/internal/pkg/scalable/scaledobjects.go
@@ -69,3 +69,42 @@ func (s *scaledObject) Update(clientsets *Clientsets, ctx context.Context) error
 
 	return nil
 }
+
+// getTargetRefName return the name of ScaledObject TargetRef
+func (s *scaledObject) getTargetRefName() (string, error) {
+	if s.Spec.ScaleTargetRef.Name == "" {
+		return "", fmt.Errorf("scaledObject %s/%s has no targetRef.Name", s.Namespace, s.Name)
+	}
+	return s.Spec.ScaleTargetRef.Name, nil
+}
+
+// getTargetRefKind return the kind of ScaledObject TargetRef
+func (s *scaledObject) getTargetRefKind() (string, error) {
+	if s.Spec.ScaleTargetRef.Kind == "" {
+		return "", fmt.Errorf("scaledObject %s/%s has no targetRef.Kind", s.Namespace, s.Name)
+	}
+	return s.Spec.ScaleTargetRef.Kind, nil
+}
+
+// computeKedaHash generates a hash for the ScaleTargetRef from a given ScaledObject.
+/*
+func (s *scaledObject) computeKedaHash() (uint64, error) {
+	// Ensure scaledObject is not nil
+	if s == nil {
+		return 0, fmt.Errorf("scaledObject is nil")
+	}
+
+	// Retrieve the ScaleTargetRef
+	scaleTargetRef := s.Spec.ScaleTargetRef
+	if scaleTargetRef.Name == "" || scaleTargetRef.Kind == "" || scaleTargetRef.APIVersion == "" {
+		return 0, fmt.Errorf("ScaleTargetRef fields are incomplete")
+	}
+
+	computedHash, err := computeHash(scaleTargetRef.Kind, scaleTargetRef.Name, s.Namespace)
+	if err != nil {
+		return 0, fmt.Errorf("failed to compute hash: %w", err)
+	}
+
+	// Return the hash as a hexadecimal string
+	return computedHash, nil
+}*/

--- a/internal/pkg/scalable/statefulsets.go
+++ b/internal/pkg/scalable/statefulsets.go
@@ -4,9 +4,18 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// Define the GVK for statefulsets
+var statefulSetGVK = schema.GroupVersionKind{
+	Group:   "apps",
+	Version: "v1",
+	Kind:    "StatefulSet",
+}
 
 // getStatefulSets is the getResourceFunc for StatefulSets
 func getStatefulSets(namespace string, clientsets *Clientsets, ctx context.Context) ([]Workload, error) {
@@ -24,6 +33,16 @@ func getStatefulSets(namespace string, clientsets *Clientsets, ctx context.Conte
 // statefulset is a wrapper for apps/v1.StatefulSet to implement the replicaScaledResource interface
 type statefulSet struct {
 	*appsv1.StatefulSet
+}
+
+// GetObjectKind sets the GVK for statefulSet
+func (s *statefulSet) GetObjectKind() schema.ObjectKind {
+	return s
+}
+
+// GroupVersionKind returns the GVK for statefulSet
+func (s *statefulSet) GroupVersionKind() schema.GroupVersionKind {
+	return statefulSetGVK
 }
 
 // setReplicas sets the amount of replicas on the resource. Changes won't be made on Kubernetes until update() is called

--- a/internal/pkg/values/util.go
+++ b/internal/pkg/values/util.go
@@ -157,3 +157,29 @@ func GetLayerFromEnv() (Layer, error) {
 
 	return result, nil
 }
+
+// OrderIncludeResourcesArgument orders the includeResources argument to have "scaledobjects" as the first element
+func OrderIncludeResourcesArgument(originalIncludeResources []string) []string {
+	scaledObjectsPresent := false
+	for _, resource := range originalIncludeResources {
+		if resource == "scaledobjects" {
+			scaledObjectsPresent = true
+			break
+		}
+	}
+
+	if scaledObjectsPresent {
+		var orderedIncludeResources []string
+		for _, resource := range originalIncludeResources {
+			if resource != "scaledobjects" {
+				orderedIncludeResources = append(orderedIncludeResources, resource)
+			}
+		}
+
+		orderedIncludeResources = append([]string{"scaledobjects"}, orderedIncludeResources...)
+
+		return orderedIncludeResources
+	}
+
+	return originalIncludeResources
+}


### PR DESCRIPTION
## Motivation

As stated in #64: workloads managed by ScaledObjects are currently also scaled by the Downscaler. This results in the ScaledObject and the downscaler fighting to downscale those workloads to (possibly) different Replicas.

This PRs solves this problem by excluding from downscaling all the workloads managed by a Keda ScaledObject. The solution works in this way:

**_Prerequisite_**: all ScaledObjects should be processed first by the algorithm 

- Inside the `FilterExcluded` function:
  - When the algorithm encounters a ScaledObject:
    - It computes a hash for the ScaledObject's `targetRef`, which is derived from the combination of (Kind+Name+Namespace):
    - The computed hash is stored in a hashMap for reference.
  - When the algorithm encounters every other workloads (Deployment, StatefulSet, ...):
    - The `isManagedByKeda` function computes a hash for the workload using (Kind+Name+Namespace)
    - It checks if the computed hash exists in the hashMap.
      - If a match is found in the hashMap, the workload is excluded from scaling as it is considered managed by KEDA. 

## Changes

- Refactored `FilterExcluded` to implement the solution proposed
- Introduced `computeHash` function to compute a Sum64 hash
- Introduce `OrderIncludeResourcesArgument` function to enforce the order of submission for resources inside `--include-resources` argument
- Introduced inside each Kubernetes Native class its `GroupVersionKind`

## Tests done

- Unit Tests
- Live Tests

## TODO

- [ ] Check Native GroupVersionKind Existence for these CRDs (Rollout, Stack, Prometheus)
- [ ] Add More Unit Tests

