### PR TITLE
fix: env vars parsing for runtime config

### DIFF
--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -42,24 +42,29 @@ func main() {
 		Kubeconfig:        "",
 	}
 
+	config.ParseConfigFlags()
+
+	err := config.ParseConfigEnvVars()
+	if err != nil {
+		slog.Error("failed to parse env vars for config", "error", err)
+		os.Exit(1)
+	}
+
 	layerCli := values.NewLayer()
 	layerEnv := values.NewLayer()
 
-	// set defaults for layers
-	layerCli.GracePeriod = defaultGracePeriod
-	layerCli.DownscaleReplicas = defaultDownscaleReplicas
-
-	config.ParseConfigFlags()
-
-	layerCli.ParseLayerFlags()
-
-	flag.Parse()
-
-	err := layerEnv.GetLayerFromEnv()
+	err = layerEnv.GetLayerFromEnv()
 	if err != nil {
 		slog.Error("failed to get layer from env", "error", err)
 		os.Exit(1)
 	}
+
+	// set defaults for layers
+	layerCli.GracePeriod = defaultGracePeriod
+	layerCli.DownscaleReplicas = defaultDownscaleReplicas
+	layerCli.ParseLayerFlags()
+
+	flag.Parse()
 
 	if config.Debug || config.DryRun {
 		slog.SetLogLoggerLevel(slog.LevelDebug)


### PR DESCRIPTION
## Motivation

<!--
Explain briefly what this change aims to achieve and why it is important to do so.
Please keep this description updated with any discussion that takes place so
that reviewers can understand your intent. Keeping the description updated is
especially important if they didn't participate in the discussion.
-->
Env vars were not being parsed after the last refactoring. This fixes this and additionally slightly refactors the order of parsing env and flags.

Bug found by @samuel-esp.

## Changes

<!--
List the changes made to the code base. Per default, all commits are listed here.
Please keep this description updated as you add new changes to the PR.
-->

## Tests done

<!--
List the tests that were done to verify the changes.
-->

## TODO

<!--
List the things that still need to be done.
-->
