### PR TITLE
fix: err on missing time annotation

### DIFF
--- a/internal/pkg/values/scope_test.go
+++ b/internal/pkg/values/scope_test.go
@@ -457,3 +457,53 @@ func TestScopes_GetExcluded(t *testing.T) {
 		})
 	}
 }
+
+func TestGetWorkloadCreationTime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		annotation   string
+		annotations  map[string]string
+		creationTime time.Time
+		want         time.Time
+		wantErr      bool
+	}{
+		{
+			name:         "use annotation",
+			annotation:   "created",
+			annotations:  map[string]string{"created": "2025-02-01T00:00:00Z"},
+			creationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			want:         time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+			wantErr:      false,
+		},
+		{
+			name:         "default to creationTime",
+			annotation:   "created",
+			creationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			want:         time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			wantErr:      false,
+		},
+		{
+			name:         "use creationTime",
+			creationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			want:         time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			wantErr:      false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := getWorkloadCreationTime(test.annotation, test.annotations, test.creationTime, nil, t.Context())
+			assert.Equal(t, test.want, got)
+
+			if test.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

<!--
Explain briefly what this change aims to achieve and why it is important to do so.
Please keep this description updated with any discussion that takes place so
that reviewers can understand your intent. Keeping the description updated is
especially important if they didn't participate in the discussion.
-->
closes #141 

## Changes

<!--
List the changes made to the code base. Per default, all commits are listed here.
Please keep this description updated as you add new changes to the PR.
-->
the downscaler will now default to the creationTime when the time annotation isn't set on a workload instead of erroring and skipping the workload

## Tests done

<!--
List the tests that were done to verify the changes.
-->

## TODO

<!--
List the things that still need to be done.
-->
