### PR TITLE
chore: add keep younger than

### DIFF
--- a/.github/workflows/prune.yaml
+++ b/.github/workflows/prune.yaml
@@ -20,6 +20,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           organization: ${{ github.repository_owner }}
           container: gokubedownscaler
+          keep-younger-than: 1 # days
           prune-untagged: true
 
       - name: Delete Cosign Signatures


### PR DESCRIPTION
## Motivation
We should keep untagged versions younger than one day to avoid deleting needed packages.

## Changes
- add keep younger than
<!--
List the changes made to the code base. Per default, all commits are listed here.
Please keep this description updated as you add new changes to the PR.
-->



<!--
List the tests that were done to verify the changes.
-->



<!--
List the things that still need to be done.
-->
