### PR TITLE
Feat/scale workload only if its ownerReference is among includedResources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: prettier
         files: \.(md|mdx)$
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.17.2
+    rev: v0.18.0
     hooks:
       - id: markdownlint-cli2
         args: [--fix]

--- a/cmd/kubedownscaler/errors.go
+++ b/cmd/kubedownscaler/errors.go
@@ -14,14 +14,14 @@ func (n *NamespaceScopeRetrieveError) Error() string {
 	return fmt.Sprintf("failed to get namespace scope for namespace %q", n.namespace)
 }
 
-type MaxRetriesExceeded struct {
+type MaxRetriesExceededError struct {
 	maxRetries int
 }
 
 func newMaxRetriesExceeded(maxRetries int) error {
-	return &MaxRetriesExceeded{maxRetries: maxRetries}
+	return &MaxRetriesExceededError{maxRetries: maxRetries}
 }
 
-func (m *MaxRetriesExceeded) Error() string {
+func (m *MaxRetriesExceededError) Error() string {
 	return fmt.Sprintf("failed to scale resource: number of max retries exceeded (%d) will try again in the next cycle", m.maxRetries)
 }

--- a/cmd/kubedownscaler/errors.go
+++ b/cmd/kubedownscaler/errors.go
@@ -13,3 +13,15 @@ func newNamespaceScopeRetrieveError(namespace string) error {
 func (n *NamespaceScopeRetrieveError) Error() string {
 	return fmt.Sprintf("failed to get namespace scope for namespace %q", n.namespace)
 }
+
+type MaxRetriesExceeded struct {
+	maxRetries int
+}
+
+func newMaxRetriesExceeded(maxRetries int) error {
+	return &MaxRetriesExceeded{maxRetries: maxRetries}
+}
+
+func (m *MaxRetriesExceeded) Error() string {
+	return fmt.Sprintf("failed to scale resource: number of max retries exceeded (%d) will try again in the next cycle", m.maxRetries)
+}

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"log/slog"

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -246,7 +246,7 @@ func attemptScaling(
 
 	slog.Error("failed to scale workload", "attempts", config.MaxRetriesOnConflict+1)
 
-	return errors.New("exceeded max retries for scaling workload")
+	return fmt.Errorf("exceeded max retries for scaling workload")
 }
 
 // nolint: cyclop // it is a big function and we can refactor it a bit but it should be fine for now

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -251,7 +251,6 @@ func attemptScaling(
 
 // nolint: cyclop // it is a big function and we can refactor it a bit but it should be fine for now
 // scanWorkload runs a scan on the worklod, determining the scaling and scaling the workload.
-// Updated scanWorkload to use the refactored functions.
 func scanWorkload(
 	workload scalable.Workload,
 	client kubernetes.Client,
@@ -275,6 +274,8 @@ func scanWorkload(
 	}
 
 	scopes := values.Scopes{scopeWorkload, scopeNamespace, scopeCli, scopeEnv, scopeDefault}
+
+	slog.Debug("finished parsing all scopes", "scopes", scopes, "workload", workload.GetName(), "namespace", workload.GetNamespace())
 
 	isInGracePeriod, err := scopes.IsInGracePeriod(
 		config.TimeAnnotation,
@@ -320,7 +321,7 @@ func scanWorkload(
 	return nil
 }
 
-// scaleWorkloads triggers scaling for a list of workloads without waiting for results.
+// scaleWorkloads scales the given workloads to the specified scaling asynchronously.
 func scaleWorkloads(
 	scaling values.Scaling,
 	workloads []scalable.Workload,

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -162,7 +162,18 @@ func startScanning(
 			return fmt.Errorf("failed to get workloads: %w", err)
 		}
 
-		workloads = scalable.FilterExcluded(workloads, config.IncludeLabels, config.ExcludeNamespaces, config.ExcludeWorkloads)
+		includedResourcesKindSet, err := client.GetKinds(config.IncludeResources)
+		if err != nil {
+			return fmt.Errorf("failed to get kinds for included resources: %w", err)
+		}
+
+		workloads = scalable.FilterExcluded(
+			workloads,
+			config.IncludeLabels,
+			config.ExcludeNamespaces,
+			config.ExcludeWorkloads,
+			includedResourcesKindSet,
+		)
 		slog.Info("scanning over workloads matching filters", "amount", len(workloads))
 
 		namespaceScopes, err := client.GetNamespaceScopes(workloads, ctx)

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -157,7 +157,7 @@ func startScanning(
 	for {
 		slog.Info("scanning workloads")
 
-		workloads, workloadsUIDToWorkload, err := client.GetWorkloads(config.IncludeNamespaces, config.IncludeResources, ctx)
+		workloads, err := client.GetWorkloads(config.IncludeNamespaces, config.IncludeResources, ctx)
 		if err != nil {
 			return fmt.Errorf("failed to get workloads: %w", err)
 		}
@@ -173,7 +173,6 @@ func startScanning(
 			config.ExcludeNamespaces,
 			config.ExcludeWorkloads,
 			includedResourcesKindSet,
-			workloadsUIDToWorkload,
 		)
 		slog.Info("scanning over workloads matching filters", "amount", len(workloads))
 

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -162,17 +162,11 @@ func startScanning(
 			return fmt.Errorf("failed to get workloads: %w", err)
 		}
 
-		includedResourcesKindSet, err := client.GetKinds(config.IncludeResources)
-		if err != nil {
-			return fmt.Errorf("failed to get kinds for included resources: %w", err)
-		}
-
 		workloads = scalable.FilterExcluded(
 			workloads,
 			config.IncludeLabels,
 			config.ExcludeNamespaces,
 			config.ExcludeWorkloads,
-			includedResourcesKindSet,
 		)
 		slog.Info("scanning over workloads matching filters", "amount", len(workloads))
 

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -352,7 +352,9 @@ func scaleChildrenWorkloads(
 
 			err = scaleWorkload(scaling, childWorkload, scopes, client, ctx)
 			if err != nil {
-				errCh <- err
+				if !strings.Contains(err.Error(), registry.OptimisticLockErrorMsg) {
+					errCh <- fmt.Errorf("failed to scale workload %s: %w", childWorkload.GetName(), err)
+				}
 			}
 		}(childWorkload)
 	}

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -246,7 +246,8 @@ func attemptScaling(
 
 	slog.Error("failed to scale workload", "attempts", config.MaxRetriesOnConflict+1)
 
-	return errors.New("exceeded max retries for scaling workload")
+	return errMaxRetriesExcedeed
+
 }
 
 // nolint: cyclop // it is a big function and we can refactor it a bit but it should be fine for now

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -246,7 +246,7 @@ func attemptScaling(
 
 	slog.Error("failed to scale workload", "attempts", config.MaxRetriesOnConflict+1)
 
-	return fmt.Errorf("exceeded max retries for scaling workload")
+	return errors.New("exceeded max retries for scaling workload")
 }
 
 // nolint: cyclop // it is a big function and we can refactor it a bit but it should be fine for now

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -246,7 +246,7 @@ func attemptScaling(
 
 	slog.Error("failed to scale workload", "attempts", config.MaxRetriesOnConflict+1)
 
-	return errMaxRetriesExcedeed
+	return newMaxRetriesExceeded(config.MaxRetriesOnConflict)
 }
 
 // nolint: cyclop // it is a big function and we can refactor it a bit but it should be fine for now
@@ -262,6 +262,12 @@ func scanWorkload(
 	resourceLogger := kubernetes.NewResourceLoggerForWorkload(client, workload)
 
 	var err error
+	slog.Debug(
+		"parsing workload scope from annotations",
+		"annotations", workload.GetAnnotations(),
+		"name", workload.GetName(),
+		"namespace", workload.GetNamespace(),
+	)
 
 	scopeWorkload := values.NewScope()
 	if err = scopeWorkload.GetScopeFromAnnotations(workload.GetAnnotations(), resourceLogger, ctx); err != nil {

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -157,7 +157,7 @@ func startScanning(
 	for {
 		slog.Info("scanning workloads")
 
-		workloads, err := client.GetWorkloads(config.IncludeNamespaces, config.IncludeResources, ctx)
+		workloads, workloadsUIDToWorkload, err := client.GetWorkloads(config.IncludeNamespaces, config.IncludeResources, ctx)
 		if err != nil {
 			return fmt.Errorf("failed to get workloads: %w", err)
 		}
@@ -173,6 +173,7 @@ func startScanning(
 			config.ExcludeNamespaces,
 			config.ExcludeWorkloads,
 			includedResourcesKindSet,
+			workloadsUIDToWorkload,
 		)
 		slog.Info("scanning over workloads matching filters", "amount", len(workloads))
 

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -85,6 +85,7 @@ func main() {
 	runWithLeaderElection(client, cancel, ctx, scopeDefault, scopeCli, scopeEnv, config)
 }
 
+// runWithLeaderElection runs the downscaler with leader election enabled.
 func runWithLeaderElection(
 	client kubernetes.Client,
 	cancel context.CancelFunc,
@@ -132,6 +133,7 @@ func runWithLeaderElection(
 	})
 }
 
+// runWithoutLeaderElection runs the downscaler without leader election enabled.
 func runWithoutLeaderElection(
 	client kubernetes.Client,
 	ctx context.Context,
@@ -147,6 +149,7 @@ func runWithoutLeaderElection(
 	}
 }
 
+// startScanning periodically triggers a scan on all workloads.
 func startScanning(
 	client kubernetes.Client,
 	ctx context.Context,
@@ -210,6 +213,7 @@ func startScanning(
 	return nil
 }
 
+// attemptScan is a wrapper for scanWorkload to handle retries on concurrent writes.
 func attemptScan(
 	client kubernetes.Client,
 	ctx context.Context,

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -247,7 +247,6 @@ func attemptScaling(
 	slog.Error("failed to scale workload", "attempts", config.MaxRetriesOnConflict+1)
 
 	return errMaxRetriesExcedeed
-
 }
 
 // nolint: cyclop // it is a big function and we can refactor it a bit but it should be fine for now

--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -35,7 +35,7 @@ type Client interface {
 	// GetNamespaceScopes gets the namespace scope from the namespace annotations
 	GetNamespaceScopes(workloads []scalable.Workload, ctx context.Context) (map[string]*values.Scope, error)
 	// GetWorkloads gets all workloads of the specified resources for the specified namespaces
-	GetWorkloads(namespaces []string, resourceTypes []string, ctx context.Context) ([]scalable.Workload, map[types.UID]scalable.Workload, error)
+	GetWorkloads(namespaces []string, resourceTypes []string, ctx context.Context) ([]scalable.Workload, map[types.UID]*scalable.Workload, error)
 	// GetKinds gets the kinds of the specified resources
 	GetKinds(resourceTypes []string) (map[string]struct{}, error)
 	// RegetWorkload gets the workload again to ensure the latest state
@@ -117,7 +117,7 @@ func (c client) GetWorkloads(
 	namespaces,
 	resourceTypes []string,
 	ctx context.Context,
-) ([]scalable.Workload, map[types.UID]scalable.Workload, error) {
+) ([]scalable.Workload, map[types.UID]*scalable.Workload, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -140,10 +140,10 @@ func (c client) GetWorkloads(
 		}
 	}
 
-	UIDToWorkloadMap := make(map[types.UID]scalable.Workload, len(results))
+	UIDToWorkloadMap := make(map[types.UID]*scalable.Workload, len(results))
 
-	for _, workload := range results {
-		UIDToWorkloadMap[workload.GetUID()] = workload
+	for i := range results {
+		UIDToWorkloadMap[results[i].GetUID()] = &results[i] // Store pointer to the workload
 	}
 
 	return results, UIDToWorkloadMap, nil

--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -28,7 +28,6 @@ const (
 )
 
 // Client is an interface representing a high-level client to get and modify Kubernetes resources.
-
 type Client interface {
 	// GetNamespaceScopes gets the namespace scope from the namespace annotations
 	GetNamespaceScopes(workloads []scalable.Workload, ctx context.Context) (map[string]*values.Scope, error)

--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -33,6 +33,8 @@ type Client interface {
 	GetNamespaceScopes(workloads []scalable.Workload, ctx context.Context) (map[string]*values.Scope, error)
 	// GetWorkloads gets all workloads of the specified resources for the specified namespaces
 	GetWorkloads(namespaces []string, resourceTypes []string, ctx context.Context) ([]scalable.Workload, error)
+	// GetKinds gets the kinds of the specified resources
+	GetKinds(resourceTypes []string) (map[string]struct{}, error)
 	// RegetWorkload gets the workload again to ensure the latest state
 	RegetWorkload(workload scalable.Workload, ctx context.Context) error
 	// DownscaleWorkload downscales the workload to the specified replicas
@@ -132,6 +134,22 @@ func (c client) GetWorkloads(namespaces, resourceTypes []string, ctx context.Con
 	}
 
 	return results, nil
+}
+
+// GetKinds gets the kinds of the specified resources.
+func (c client) GetKinds(resourceTypes []string) (map[string]struct{}, error) {
+	kinds := make(map[string]struct{}, len(resourceTypes))
+
+	for _, resource := range resourceTypes {
+		kind, err := scalable.GetKind(resource)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get kind for resource type '%s': %w", resource, err)
+		}
+
+		kinds[kind] = struct{}{}
+	}
+
+	return kinds, nil
 }
 
 // RegetWorkload gets the workload again to ensure the latest state.

--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -30,12 +30,12 @@ const (
 
 // Client is an interface representing a high-level client to get and modify Kubernetes resources.
 //
-//nolint:lll // ignore long line length for client interface
+
 type Client interface {
 	// GetNamespaceScopes gets the namespace scope from the namespace annotations
 	GetNamespaceScopes(workloads []scalable.Workload, ctx context.Context) (map[string]*values.Scope, error)
 	// GetWorkloads gets all workloads of the specified resources for the specified namespaces
-	GetWorkloads(namespaces []string, resourceTypes []string, ctx context.Context) ([]scalable.Workload, map[types.UID]*scalable.Workload, error)
+	GetWorkloads(namespaces []string, resourceTypes []string, ctx context.Context) ([]scalable.Workload, error)
 	// GetKinds gets the kinds of the specified resources
 	GetKinds(resourceTypes []string) (map[string]struct{}, error)
 	// RegetWorkload gets the workload again to ensure the latest state
@@ -117,7 +117,7 @@ func (c client) GetWorkloads(
 	namespaces,
 	resourceTypes []string,
 	ctx context.Context,
-) ([]scalable.Workload, map[types.UID]*scalable.Workload, error) {
+) ([]scalable.Workload, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -133,7 +133,7 @@ func (c client) GetWorkloads(
 
 			workloads, err := scalable.GetWorkloads(strings.ToLower(resourceType), namespace, c.clientsets, ctx)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to get workloads: %w", err)
+				return nil, fmt.Errorf("failed to get workloads: %w", err)
 			}
 
 			results = append(results, workloads...)
@@ -146,7 +146,7 @@ func (c client) GetWorkloads(
 		UIDToWorkloadMap[results[i].GetUID()] = &results[i] // Store pointer to the workload
 	}
 
-	return results, UIDToWorkloadMap, nil
+	return results, nil
 }
 
 // GetKinds gets the kinds of the specified resources.

--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -18,7 +18,6 @@ import (
 	zalando "github.com/zalando-incubator/stackset-controller/pkg/clientset"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 )
@@ -29,7 +28,6 @@ const (
 )
 
 // Client is an interface representing a high-level client to get and modify Kubernetes resources.
-//
 
 type Client interface {
 	// GetNamespaceScopes gets the namespace scope from the namespace annotations
@@ -136,12 +134,6 @@ func (c client) GetWorkloads(
 
 			results = append(results, workloads...)
 		}
-	}
-
-	UIDToWorkloadMap := make(map[types.UID]*scalable.Workload, len(results))
-
-	for i := range results {
-		UIDToWorkloadMap[results[i].GetUID()] = &results[i] // Store pointer to the workload
 	}
 
 	return results, nil

--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -36,8 +36,6 @@ type Client interface {
 	GetNamespaceScopes(workloads []scalable.Workload, ctx context.Context) (map[string]*values.Scope, error)
 	// GetWorkloads gets all workloads of the specified resources for the specified namespaces
 	GetWorkloads(namespaces []string, resourceTypes []string, ctx context.Context) ([]scalable.Workload, error)
-	// GetKinds gets the kinds of the specified resources
-	GetKinds(resourceTypes []string) (map[string]struct{}, error)
 	// RegetWorkload gets the workload again to ensure the latest state
 	RegetWorkload(workload scalable.Workload, ctx context.Context) error
 	// DownscaleWorkload downscales the workload to the specified replicas
@@ -147,22 +145,6 @@ func (c client) GetWorkloads(
 	}
 
 	return results, nil
-}
-
-// GetKinds gets the kinds of the specified resources.
-func (c client) GetKinds(resourceTypes []string) (map[string]struct{}, error) {
-	kinds := make(map[string]struct{}, len(resourceTypes))
-
-	for _, resource := range resourceTypes {
-		kind, err := scalable.GetKind(resource)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get kind for resource type '%s': %w", resource, err)
-		}
-
-		kinds[kind] = struct{}{}
-	}
-
-	return kinds, nil
 }
 
 // RegetWorkload gets the workload again to ensure the latest state.

--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -147,7 +147,12 @@ func (c client) GetChildrenWorkloads(workload scalable.Workload, ctx context.Con
 	defer cancel()
 
 	if parent, ok := workload.(scalable.ParentWorkload); ok {
-		slog.Debug("getting children workloads for workload", "workload", workload.GetName(), "namespace", workload.GetNamespace(), "resourceType", workload.GroupVersionKind().Kind)
+		slog.Debug(
+			"getting children workloads for workload",
+			"workload", workload.GetName(),
+			"namespace", workload.GetNamespace(),
+			"resourceType", workload.GroupVersionKind().Kind,
+		)
 
 		children, err := parent.GetChildren(ctx, c.clientsets)
 		if err != nil {

--- a/internal/pkg/scalable/cronjobs.go
+++ b/internal/pkg/scalable/cronjobs.go
@@ -15,7 +15,7 @@ import (
 func getCronJobs(namespace string, clientsets *Clientsets, ctx context.Context) ([]Workload, error) {
 	cronjobs, err := clientsets.Kubernetes.BatchV1().CronJobs(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("%w: failed to convert workload to cronjobs", errConversionFailed)
+		return nil, fmt.Errorf("failed to get cronjobs: %w", err)
 	}
 
 	results := make([]Workload, 0, len(cronjobs.Items))
@@ -26,19 +26,15 @@ func getCronJobs(namespace string, clientsets *Clientsets, ctx context.Context) 
 	return results, nil
 }
 
-// getCronJobsChildren is the getResourceFunc for CronJobs children (Jobs).
-func getCronJobsChildren(workload Workload, clientsets *Clientsets, ctx context.Context) ([]Workload, error) {
-	cronjob, ok := workload.(*suspendScaledWorkload).suspendScaledResource.(*cronJob)
-	if !ok {
-		return nil, fmt.Errorf("%w: %v", errConversionFailed, workload)
-	}
-
-	activeJobs := cronjob.Status.Active
+func (c *cronJob) GetChildren(ctx context.Context, clientsets *Clientsets) ([]Workload, error) {
+	activeJobs := c.Status.Active
 
 	var waitGroup sync.WaitGroup
+
+	var mutex sync.Mutex
+
 	errChannel := make(chan error, len(activeJobs))
 	results := make([]Workload, 0, len(activeJobs))
-	allErrors := make([]error, 0, len(activeJobs))
 
 	for _, activeJob := range activeJobs {
 		waitGroup.Add(1)
@@ -46,20 +42,22 @@ func getCronJobsChildren(workload Workload, clientsets *Clientsets, ctx context.
 		go func(activeJob v1.ObjectReference) {
 			defer waitGroup.Done()
 
-			singleJob, err := clientsets.Kubernetes.BatchV1().Jobs(workload.GetNamespace()).Get(ctx, activeJob.Name, metav1.GetOptions{})
+			singleJob, err := clientsets.Kubernetes.BatchV1().Jobs(c.Namespace).Get(ctx, activeJob.Name, metav1.GetOptions{})
 			if err != nil {
 				errChannel <- fmt.Errorf("failed to get job %s: %w", activeJob.Name, err)
 				return
 			}
 
+			mutex.Lock()
 			results = append(results, &suspendScaledWorkload{&job{singleJob}})
+			mutex.Unlock()
 		}(activeJob)
 	}
 
 	waitGroup.Wait()
-
 	close(errChannel)
 
+	var allErrors []error
 	for err := range errChannel {
 		allErrors = append(allErrors, err)
 	}

--- a/internal/pkg/scalable/cronjobs.go
+++ b/internal/pkg/scalable/cronjobs.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sync"
 )
 
 // getCronJobs is the getResourceFunc for CronJobs.

--- a/internal/pkg/scalable/poddisruptionbudgets_test.go
+++ b/internal/pkg/scalable/poddisruptionbudgets_test.go
@@ -145,6 +145,7 @@ func TestPodDisruptionBudget_ScaleUp(t *testing.T) {
 			}
 
 			oringalReplicas, err := getOriginalReplicas(pdb)
+
 			var originalReplicasUnsetErr *OriginalReplicasUnsetError
 
 			if ok := errors.As(err, &originalReplicasUnsetErr); !ok { // ignore getOriginalReplicas being unset
@@ -292,6 +293,7 @@ func TestPodDisruptionBudget_ScaleDown(t *testing.T) {
 			}
 
 			oringalReplicas, err := getOriginalReplicas(pdb)
+
 			var originalReplicasUnsetErr *OriginalReplicasUnsetError
 
 			if ok := errors.As(err, &originalReplicasUnsetErr); !ok { // ignore getOriginalReplicas being unset

--- a/internal/pkg/scalable/replicaScaledWorkloads_test.go
+++ b/internal/pkg/scalable/replicaScaledWorkloads_test.go
@@ -62,6 +62,7 @@ func TestReplicaScaledWorkload_ScaleUp(t *testing.T) {
 			}
 
 			oringalReplicas, err := getOriginalReplicas(deployment)
+
 			var originalReplicasUnsetErr *OriginalReplicasUnsetError
 
 			if ok := errors.As(err, &originalReplicasUnsetErr); !ok { // ignore getOriginalReplicas being unset

--- a/internal/pkg/scalable/util.go
+++ b/internal/pkg/scalable/util.go
@@ -215,7 +215,7 @@ func isWorkloadExcluded(
 	}
 
 	for _, resource := range nonControllerResources {
-		if _, exists := includedResources[resource.GetName()]; !exists {
+		if _, exists := includedResources[resource.GroupVersionKind().String()]; !exists {
 			return true
 		}
 	}

--- a/internal/pkg/scalable/util.go
+++ b/internal/pkg/scalable/util.go
@@ -213,7 +213,7 @@ func checkAllReferencesExcluded(ownerReferences *[]Workload, includedResources m
 
 // getOwnerReferenceParent recursively finds the root owner of the workload by following controller owner references.
 //
-//nolint:gocritic // this function should return a pointer
+//nolint:gocritic // ptrToReference should be allowed
 func getOwnerReferenceParent(workload *Workload, uidToWorkload map[types.UID]*Workload) *Workload {
 	for _, ownerReference := range (*workload).GetOwnerReferences() {
 		if ownerReference.Controller != nil && *ownerReference.Controller {
@@ -228,7 +228,7 @@ func getOwnerReferenceParent(workload *Workload, uidToWorkload map[types.UID]*Wo
 
 // getNonControllerOwnerReferences returns non-controller owner references of the workload.
 //
-//nolint:gocritic // this function should return a pointer
+//nolint:gocritic // ptrToReference should be allowed
 func getNonControllerOwnerReferences(
 	workload *Workload,
 	uidToWorkload map[types.UID]*Workload,

--- a/internal/pkg/scalable/util.go
+++ b/internal/pkg/scalable/util.go
@@ -189,15 +189,13 @@ func isWorkloadExcluded(
 
 // isManagedByOwnerReference checks if the workload is managed by an owner reference that is in the includedResources list.
 func isManagedByOwnerReference(workload Workload) bool {
-	isExcluded := false
-
 	for _, ownerReference := range workload.GetOwnerReferences() {
 		if *ownerReference.Controller {
-			isExcluded = true
+			return true
 		}
 	}
 
-	return isExcluded
+	return false
 }
 
 // setOriginalReplicas sets the original replicas annotation on the workload.

--- a/internal/pkg/scalable/util.go
+++ b/internal/pkg/scalable/util.go
@@ -176,12 +176,12 @@ func isWorkloadExcluded(
 	workload Workload,
 	excludedWorkloads util.RegexList,
 ) bool {
-	if excludedWorkloads == nil {
-		return false
-	}
-
 	if isManagedByOwnerReference(workload) {
 		return true
+	}
+
+	if excludedWorkloads == nil {
+		return false
 	}
 
 	return excludedWorkloads.CheckMatchesAny(workload.GetName())

--- a/internal/pkg/scalable/util.go
+++ b/internal/pkg/scalable/util.go
@@ -190,7 +190,7 @@ func isWorkloadExcluded(
 // isManagedByOwnerReference checks if the workload is managed by an owner reference that is in the includedResources list.
 func isManagedByOwnerReference(workload Workload) bool {
 	for _, ownerReference := range workload.GetOwnerReferences() {
-		if *ownerReference.Controller {
+		if ownerReference.Controller != nil && *ownerReference.Controller {
 			return true
 		}
 	}

--- a/internal/pkg/scalable/util_test.go
+++ b/internal/pkg/scalable/util_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestFilterExcluded(t *testing.T) {
@@ -93,14 +92,6 @@ func TestFilterExcluded(t *testing.T) {
 		}}},
 	}
 
-	workloadsUIDToWorkload := map[types.UID]*Workload{
-		types.UID("uid1"): &ns1.deployment1,
-		types.UID("uid2"): &ns1.deployment2,
-		types.UID("uid3"): &ns3.deployment1,
-		types.UID("uid4"): &ns3.deployment2,
-		types.UID("uid5"): &ns3.scaledObject,
-	}
-
 	tests := []struct {
 		name               string
 		workloads          []Workload
@@ -167,7 +158,7 @@ func TestFilterExcluded(t *testing.T) {
 				test.excludedNamespaces,
 				test.excludedWorkloads,
 				test.includedResources,
-				workloadsUIDToWorkload)
+			)
 
 			assert.Equal(t, test.want, got)
 		})

--- a/internal/pkg/scalable/util_test.go
+++ b/internal/pkg/scalable/util_test.go
@@ -98,6 +98,7 @@ func TestFilterExcluded(t *testing.T) {
 		excludedNamespaces util.RegexList
 		excludedWorkloads  util.RegexList
 		want               []Workload
+		includedResources  map[string]struct{}
 	}{
 		{
 			name:               "none set",
@@ -106,6 +107,7 @@ func TestFilterExcluded(t *testing.T) {
 			excludedNamespaces: nil,
 			excludedWorkloads:  nil,
 			want:               []Workload{ns1.deployment1, ns1.deployment2, ns2.deployment1},
+			includedResources:  nil,
 		},
 		{
 			name:               "includeLabels",
@@ -114,6 +116,7 @@ func TestFilterExcluded(t *testing.T) {
 			excludedNamespaces: nil,
 			excludedWorkloads:  nil,
 			want:               []Workload{ns1.labeledDeployment},
+			includedResources:  nil,
 		},
 		{
 			name:               "excludeNamespaces",
@@ -122,6 +125,7 @@ func TestFilterExcluded(t *testing.T) {
 			excludedNamespaces: util.RegexList{regexp.MustCompile("Namespace1")}, // exclude Namespace1
 			excludedWorkloads:  nil,
 			want:               []Workload{ns2.deployment1},
+			includedResources:  nil,
 		},
 		{
 			name:               "excludeWorkloads",
@@ -130,6 +134,7 @@ func TestFilterExcluded(t *testing.T) {
 			excludedNamespaces: nil,
 			excludedWorkloads:  util.RegexList{regexp.MustCompile("Deployment1")}, // exclude Deployment1
 			want:               []Workload{ns1.deployment2},
+			includedResources:  nil,
 		},
 		{
 			name:               "exclude scaled object scaled",
@@ -138,6 +143,7 @@ func TestFilterExcluded(t *testing.T) {
 			excludedNamespaces: nil,
 			excludedWorkloads:  nil,
 			want:               []Workload{ns3.deployment1, ns3.scaledObject, ns1.deployment1, ns1.deployment2, ns2.deployment1},
+			includedResources:  map[string]struct{}{"Deployment": {}},
 		},
 	}
 
@@ -145,7 +151,7 @@ func TestFilterExcluded(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := FilterExcluded(test.workloads, test.includeLabels, test.excludedNamespaces, test.excludedWorkloads)
+			got := FilterExcluded(test.workloads, test.includeLabels, test.excludedNamespaces, test.excludedWorkloads, test.includedResources)
 			assert.Equal(t, test.want, got)
 		})
 	}

--- a/internal/pkg/scalable/util_test.go
+++ b/internal/pkg/scalable/util_test.go
@@ -93,12 +93,12 @@ func TestFilterExcluded(t *testing.T) {
 		}}},
 	}
 
-	workloadsUIDToWorkload := map[types.UID]Workload{
-		types.UID("uid1"): ns1.deployment1,
-		types.UID("uid2"): ns1.deployment2,
-		types.UID("uid3"): ns3.deployment1,
-		types.UID("uid4"): ns3.deployment2,
-		types.UID("uid5"): ns3.scaledObject,
+	workloadsUIDToWorkload := map[types.UID]*Workload{
+		types.UID("uid1"): &ns1.deployment1,
+		types.UID("uid2"): &ns1.deployment2,
+		types.UID("uid3"): &ns3.deployment1,
+		types.UID("uid4"): &ns3.deployment2,
+		types.UID("uid5"): &ns3.scaledObject,
 	}
 
 	tests := []struct {

--- a/internal/pkg/scalable/util_test.go
+++ b/internal/pkg/scalable/util_test.go
@@ -21,6 +21,7 @@ func TestFilterExcluded(t *testing.T) {
 		labeledDeployment Workload
 		scaledObject      Workload
 	}
+
 	ns1 := ns{
 		deployment1: &replicaScaledWorkload{&deployment{Deployment: &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/pkg/scalable/util_test.go
+++ b/internal/pkg/scalable/util_test.go
@@ -157,7 +157,6 @@ func TestFilterExcluded(t *testing.T) {
 				test.includeLabels,
 				test.excludedNamespaces,
 				test.excludedWorkloads,
-				test.includedResources,
 			)
 
 			assert.Equal(t, test.want, got)

--- a/internal/pkg/scalable/util_test.go
+++ b/internal/pkg/scalable/util_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestFilterExcluded(t *testing.T) {
@@ -91,6 +92,12 @@ func TestFilterExcluded(t *testing.T) {
 			},
 		}}},
 	}
+
+	workloadsUIDToWorkload := map[types.UID]Workload{
+		types.UID("uid1"): ns1.deployment1,
+		types.UID("uid2"): ns1.deployment2,
+	}
+
 	tests := []struct {
 		name               string
 		workloads          []Workload
@@ -151,7 +158,14 @@ func TestFilterExcluded(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := FilterExcluded(test.workloads, test.includeLabels, test.excludedNamespaces, test.excludedWorkloads, test.includedResources)
+			got := FilterExcluded(
+				test.workloads,
+				test.includeLabels,
+				test.excludedNamespaces,
+				test.excludedWorkloads,
+				test.includedResources,
+				workloadsUIDToWorkload)
+
 			assert.Equal(t, test.want, got)
 		})
 	}

--- a/internal/pkg/scalable/util_test.go
+++ b/internal/pkg/scalable/util_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -20,6 +21,8 @@ func TestFilterExcluded(t *testing.T) {
 		deployment2       Workload
 		labeledDeployment Workload
 		scaledObject      Workload
+		job1              Workload
+		job2              Workload
 	}
 
 	ns1 := ns{
@@ -91,6 +94,36 @@ func TestFilterExcluded(t *testing.T) {
 				},
 			},
 		}}},
+		job1: &suspendScaledWorkload{&job{Job: &v1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "Job1",
+				Namespace: "Namespace3",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "batch/v1",
+						Kind:               "CronJob",
+						Name:               "CronJob1",
+						UID:                "4a6e4a30-c474-4bc5-9bf5-47f29430fb41",
+						Controller:         func() *bool { b := true; return &b }(),
+						BlockOwnerDeletion: func() *bool { b := true; return &b }(),
+					},
+				},
+			},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "batch/v1",
+				Kind:       "Job",
+			},
+		}}},
+		job2: &suspendScaledWorkload{&job{Job: &v1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "Job2",
+				Namespace: "Namespace3",
+			},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "batch/v1",
+				Kind:       "Job",
+			},
+		}}},
 	}
 
 	tests := []struct {
@@ -140,6 +173,14 @@ func TestFilterExcluded(t *testing.T) {
 			excludedNamespaces: nil,
 			excludedWorkloads:  nil,
 			want:               []Workload{ns3.deployment1, ns3.scaledObject, ns1.deployment1, ns1.deployment2, ns2.deployment1},
+		},
+		{
+			name:               "exclude managed by ownerReference",
+			workloads:          []Workload{ns3.deployment1, ns3.deployment2, ns3.scaledObject, ns1.deployment1, ns3.job1, ns3.job2},
+			includeLabels:      nil,
+			excludedNamespaces: nil,
+			excludedWorkloads:  nil,
+			want:               []Workload{ns3.deployment1, ns3.scaledObject, ns1.deployment1, ns3.job2},
 		},
 	}
 

--- a/internal/pkg/scalable/util_test.go
+++ b/internal/pkg/scalable/util_test.go
@@ -99,7 +99,6 @@ func TestFilterExcluded(t *testing.T) {
 		excludedNamespaces util.RegexList
 		excludedWorkloads  util.RegexList
 		want               []Workload
-		includedResources  map[string]struct{}
 	}{
 		{
 			name:               "none set",
@@ -108,7 +107,6 @@ func TestFilterExcluded(t *testing.T) {
 			excludedNamespaces: nil,
 			excludedWorkloads:  nil,
 			want:               []Workload{ns1.deployment1, ns1.deployment2, ns2.deployment1},
-			includedResources:  nil,
 		},
 		{
 			name:               "includeLabels",
@@ -117,7 +115,6 @@ func TestFilterExcluded(t *testing.T) {
 			excludedNamespaces: nil,
 			excludedWorkloads:  nil,
 			want:               []Workload{ns1.labeledDeployment},
-			includedResources:  nil,
 		},
 		{
 			name:               "excludeNamespaces",
@@ -126,7 +123,6 @@ func TestFilterExcluded(t *testing.T) {
 			excludedNamespaces: util.RegexList{regexp.MustCompile("Namespace1")}, // exclude Namespace1
 			excludedWorkloads:  nil,
 			want:               []Workload{ns2.deployment1},
-			includedResources:  nil,
 		},
 		{
 			name:               "excludeWorkloads",
@@ -135,7 +131,6 @@ func TestFilterExcluded(t *testing.T) {
 			excludedNamespaces: nil,
 			excludedWorkloads:  util.RegexList{regexp.MustCompile("Deployment1")}, // exclude Deployment1
 			want:               []Workload{ns1.deployment2},
-			includedResources:  nil,
 		},
 		{
 			name:               "exclude scaled object scaled",
@@ -144,7 +139,6 @@ func TestFilterExcluded(t *testing.T) {
 			excludedNamespaces: nil,
 			excludedWorkloads:  nil,
 			want:               []Workload{ns3.deployment1, ns3.scaledObject, ns1.deployment1, ns1.deployment2, ns2.deployment1},
-			includedResources:  map[string]struct{}{"Deployment": {}},
 		},
 	}
 

--- a/internal/pkg/scalable/util_test.go
+++ b/internal/pkg/scalable/util_test.go
@@ -96,6 +96,9 @@ func TestFilterExcluded(t *testing.T) {
 	workloadsUIDToWorkload := map[types.UID]Workload{
 		types.UID("uid1"): ns1.deployment1,
 		types.UID("uid2"): ns1.deployment2,
+		types.UID("uid3"): ns3.deployment1,
+		types.UID("uid4"): ns3.deployment2,
+		types.UID("uid5"): ns3.scaledObject,
 	}
 
 	tests := []struct {

--- a/internal/pkg/scalable/workload.go
+++ b/internal/pkg/scalable/workload.go
@@ -9,7 +9,6 @@ import (
 	monitoring "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	zalando "github.com/zalando-incubator/stackset-controller/pkg/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -49,26 +48,24 @@ func GetWorkloads(resource, namespace string, clientsets *Clientsets, ctx contex
 
 // GetKind gets the Kind for a given resource type.
 func GetKind(resource string) (string, error) {
-	resourceKindMap := map[string]runtime.Object{
-		"deployments":              &deployment{},
-		"statefulsets":             &statefulSet{},
-		"cronjobs":                 &cronJob{},
-		"jobs":                     &job{},
-		"daemonsets":               &daemonSet{},
-		"poddisruptionbudgets":     &podDisruptionBudget{},
-		"horizontalpodautoscalers": &horizontalPodAutoscaler{},
-		"scaledobjects":            &scaledObject{},
-		"rollouts":                 &rollout{},
-		"stacks":                   &stack{},
-		"prometheuses":             &prometheus{},
+	resourceKindMap := map[string]string{
+		"deployments":              "Deployment",
+		"statefulsets":             "StatefulSet",
+		"cronjobs":                 "CronJob",
+		"jobs":                     "Job",
+		"daemonsets":               "DaemonSet",
+		"poddisruptionbudgets":     "PodDisruptionBudget",
+		"horizontalpodautoscalers": "HorizontalPodAutoscaler",
+		"scaledobjects":            "ScaledObject",
+		"rollouts":                 "Rollout",
+		"stacks":                   "Stack",
+		"prometheuses":             "Prometheus",
 	}
 
-	obj, exists := resourceKindMap[resource]
+	kind, exists := resourceKindMap[resource]
 	if !exists {
 		return "", fmt.Errorf("failed to get kind of type %q: %w", resource, errResourceNotSupported)
 	}
-
-	kind := obj.GetObjectKind().GroupVersionKind().GroupKind().String()
 
 	return kind, nil
 }

--- a/internal/pkg/scalable/workload.go
+++ b/internal/pkg/scalable/workload.go
@@ -46,30 +46,6 @@ func GetWorkloads(resource, namespace string, clientsets *Clientsets, ctx contex
 	return workloads, nil
 }
 
-// GetKind gets the Kind for a given resource type.
-func GetKind(resource string) (string, error) {
-	resourceKindMap := map[string]string{
-		"deployments":              "Deployment",
-		"statefulsets":             "StatefulSet",
-		"cronjobs":                 "CronJob",
-		"jobs":                     "Job",
-		"daemonsets":               "DaemonSet",
-		"poddisruptionbudgets":     "PodDisruptionBudget",
-		"horizontalpodautoscalers": "HorizontalPodAutoscaler",
-		"scaledobjects":            "ScaledObject",
-		"rollouts":                 "Rollout",
-		"stacks":                   "Stack",
-		"prometheuses":             "Prometheus",
-	}
-
-	kind, exists := resourceKindMap[resource]
-	if !exists {
-		return "", fmt.Errorf("failed to get kind of type %q: %w", resource, errResourceNotSupported)
-	}
-
-	return kind, nil
-}
-
 // scalableResource provides all functions needed to scale any type of resource.
 type scalableResource interface {
 	// GetAnnotations gets the annotations of the resource

--- a/internal/pkg/scalable/workload.go
+++ b/internal/pkg/scalable/workload.go
@@ -46,6 +46,10 @@ func GetWorkloads(resource, namespace string, clientsets *Clientsets, ctx contex
 	return workloads, nil
 }
 
+type ParentWorkload interface {
+	GetChildren(ctx context.Context, clientsets *Clientsets) ([]Workload, error)
+}
+
 // scalableResource provides all functions needed to scale any type of resource.
 type scalableResource interface {
 	// GetAnnotations gets the annotations of the resource

--- a/internal/pkg/values/dayTime.go
+++ b/internal/pkg/values/dayTime.go
@@ -19,6 +19,7 @@ func extractDayTime(t time.Time) dayTime {
 
 func parseDayTime(s string) (*dayTime, error) {
 	var result dayTime
+
 	parts := strings.Split(s, ":")
 
 	hour, err := strconv.Atoi(parts[0])

--- a/internal/pkg/values/scope.go
+++ b/internal/pkg/values/scope.go
@@ -47,6 +47,7 @@ func NewScope() *Scope {
 	return &Scope{
 		DownscaleReplicas: util.Undefined,
 		GracePeriod:       util.Undefined,
+		ScaleChildren:     false,
 	}
 }
 
@@ -62,6 +63,7 @@ type Scope struct {
 	ForceDowntime     timeSpans     // force workload into a downtime state when in one of the timespans
 	DownscaleReplicas int32         // the replicas to scale down to
 	GracePeriod       time.Duration // grace period until new workloads will be scaled down
+	ScaleChildren     bool          // ownerReference will immediately trigger scaling of children workloads, when applicable
 }
 
 func GetDefaultScope() *Scope {
@@ -76,6 +78,7 @@ func GetDefaultScope() *Scope {
 		ForceDowntime:     nil,
 		DownscaleReplicas: 0,
 		GracePeriod:       15 * time.Minute,
+		ScaleChildren:     false,
 	}
 }
 
@@ -212,6 +215,17 @@ func (s Scopes) GetDownscaleReplicas() (int32, error) {
 	}
 
 	return 0, newValueNotSetError("downscaleReplicas")
+}
+
+// GetScaleChildren gets the scale children of the first scope that implements scale children.
+func (s Scopes) GetScaleChildren() bool {
+	for _, scope := range s {
+		if scope.ScaleChildren {
+			return true
+		}
+	}
+
+	return false
 }
 
 // GetExcluded checks if the scopes exclude scaling.

--- a/internal/pkg/values/scope.go
+++ b/internal/pkg/values/scope.go
@@ -42,12 +42,11 @@ func (s ScopeID) String() string {
 	}[s]
 }
 
-// NewScope gets a new scope with the default values.
+// NewScope gets a new scope with all values in an unset state.
 func NewScope() *Scope {
 	return &Scope{
 		DownscaleReplicas: util.Undefined,
 		GracePeriod:       util.Undefined,
-		ScaleChildren:     false,
 	}
 }
 
@@ -63,7 +62,7 @@ type Scope struct {
 	ForceDowntime     timeSpans     // force workload into a downtime state when in one of the timespans
 	DownscaleReplicas int32         // the replicas to scale down to
 	GracePeriod       time.Duration // grace period until new workloads will be scaled down
-	ScaleChildren     bool          // ownerReference will immediately trigger scaling of children workloads, when applicable
+	ScaleChildren     triStateBool  // ownerReference will immediately trigger scaling of children workloads, when applicable
 }
 
 func GetDefaultScope() *Scope {
@@ -78,7 +77,7 @@ func GetDefaultScope() *Scope {
 		ForceDowntime:     nil,
 		DownscaleReplicas: 0,
 		GracePeriod:       15 * time.Minute,
-		ScaleChildren:     false,
+		ScaleChildren:     triStateBool{isSet: false, value: false},
 	}
 }
 
@@ -220,7 +219,7 @@ func (s Scopes) GetDownscaleReplicas() (int32, error) {
 // GetScaleChildren gets the scale children of the first scope that implements scale children.
 func (s Scopes) GetScaleChildren() bool {
 	for _, scope := range s {
-		if scope.ScaleChildren {
+		if scope.ScaleChildren.isSet && scope.ScaleChildren.value {
 			return true
 		}
 	}

--- a/internal/pkg/values/scope.go
+++ b/internal/pkg/values/scope.go
@@ -219,8 +219,8 @@ func (s Scopes) GetDownscaleReplicas() (int32, error) {
 // GetScaleChildren gets the scale children of the first scope that implements scale children.
 func (s Scopes) GetScaleChildren() bool {
 	for _, scope := range s {
-		if scope.ScaleChildren.isSet && scope.ScaleChildren.value {
-			return true
+		if scope.ScaleChildren.isSet {
+			return scope.ScaleChildren.value
 		}
 	}
 

--- a/internal/pkg/values/scopeParser.go
+++ b/internal/pkg/values/scopeParser.go
@@ -70,10 +70,9 @@ func (s *Scope) ParseScopeFlags() {
 		"grace-period",
 		"the grace period between creation of workload until first downscale (default: 15min)",
 	)
-	flag.BoolVar(
-		&s.ScaleChildren.value,
+	flag.Var(
+		&s.ScaleChildren,
 		"scale-children",
-		false,
 		"if set to true, the ownerReference will immediately trigger scaling of children workloads when applicable (default: false)",
 	)
 }

--- a/internal/pkg/values/scopeParser.go
+++ b/internal/pkg/values/scopeParser.go
@@ -71,7 +71,7 @@ func (s *Scope) ParseScopeFlags() {
 		"the grace period between creation of workload until first downscale (default: 15min)",
 	)
 	flag.BoolVar(
-		&s.ScaleChildren,
+		&s.ScaleChildren.value,
 		"scale-children",
 		false,
 		"if set to true, the ownerReference will immediately trigger scaling of children workloads when applicable (default: false)",
@@ -108,7 +108,7 @@ func (s *Scope) GetScopeFromEnv() error {
 }
 
 // GetScopeFromAnnotations fills l with all values from the annotations and checks for compatibility.
-func (s *Scope) GetScopeFromAnnotations( //nolint: funlen,gocognit,gocyclo,cyclop // it is a big function and we can refactor it a bit but it should be fine for now
+func (s *Scope) GetScopeFromAnnotations( //nolint: funlen,gocognit,cyclop // it is a big function and we can refactor it a bit but it should be fine for now
 	annotations map[string]string,
 	logEvent util.ResourceLogger,
 	ctx context.Context,
@@ -225,7 +225,7 @@ func (s *Scope) GetScopeFromAnnotations( //nolint: funlen,gocognit,gocyclo,cyclo
 	}
 
 	if scaleChildrenString, ok := annotations[annotationScaleChildren]; ok {
-		s.ScaleChildren, err = strconv.ParseBool(scaleChildrenString)
+		err = s.ScaleChildren.Set(scaleChildrenString)
 		if err != nil {
 			err = fmt.Errorf("failed to parse %q annotation: %w", annotationScaleChildren, err)
 			logEvent.ErrorInvalidAnnotation(annotationScaleChildren, err.Error(), ctx)

--- a/internal/pkg/values/scopeParser.go
+++ b/internal/pkg/values/scopeParser.go
@@ -108,7 +108,7 @@ func (s *Scope) GetScopeFromEnv() error {
 }
 
 // GetScopeFromAnnotations fills l with all values from the annotations and checks for compatibility.
-func (s *Scope) GetScopeFromAnnotations( //nolint: funlen,gocognit,cyclop // it is a big function and we can refactor it a bit but it should be fine for now
+func (s *Scope) GetScopeFromAnnotations( //nolint: funlen,gocognit,cyclop,gocyclo // it is a big function and we can refactor it a bit but it should be fine for now
 	annotations map[string]string,
 	logEvent util.ResourceLogger,
 	ctx context.Context,

--- a/internal/pkg/values/timespan.go
+++ b/internal/pkg/values/timespan.go
@@ -50,6 +50,7 @@ func (t *timeSpans) Set(value string) error {
 
 	for _, timespanText := range spans {
 		var timespan TimeSpan
+
 		timespanText = strings.TrimSpace(timespanText)
 
 		timespan, ok := parseBooleanTimeSpan(timespanText)
@@ -106,6 +107,7 @@ func parseAbsoluteTimeSpan(timespan string) (absoluteTimeSpan, error) {
 
 func parseRelativeTimeSpan(timespanString string) (*relativeTimeSpan, error) {
 	var err error
+
 	timespan := relativeTimeSpan{}
 
 	parts := strings.Split(timespanString, " ")

--- a/internal/pkg/values/triStateBool.go
+++ b/internal/pkg/values/triStateBool.go
@@ -1,0 +1,40 @@
+package values
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/caas-team/gokubedownscaler/internal/pkg/util"
+)
+
+// triStateBool represents a boolean with an additional isSet field.
+type triStateBool struct {
+	isSet bool
+	value bool
+}
+
+// Set sets the value and sets isSet to true.
+func (t *triStateBool) Set(value string) error {
+	var err error
+
+	t.value, err = strconv.ParseBool(value)
+	if err != nil {
+		return fmt.Errorf("failed to parse boolean value: %w", err)
+	}
+
+	t.isSet = true
+
+	return nil
+}
+
+func (t *triStateBool) String() string {
+	if !t.isSet {
+		return util.UndefinedString
+	}
+
+	return strconv.FormatBool(t.value)
+}
+
+// IsBoolFlag is there to make triStateBool implement flag.boolFlag.
+// This lets users use the flag without needing to specify a value.
+func (t *triStateBool) IsBoolFlag() bool { return true }


### PR DESCRIPTION
## Motivation

As stated in #165 right now the KubeDownscaler cannot distinguish between resources that have ownerReferences or not during the scaling process

## Changes

- Refactored FilterExcluded (specifically the isWorkloadExcluded sub-function) to check also for ownerReference when evaluating workload scaling
- Introduced some other functions to support the logic explained above

## Tests Done

- Unit Tests

## TODO

- [ ] Live Tests
