### PR TITLE
Feat/multi-arch build

### DIFF
--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -58,7 +58,7 @@ jobs:
         id: build-push
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 

--- a/deployments/chart/Chart.yaml
+++ b/deployments/chart/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - kube-downscaler
   - go
   - downscaling
-version: 1.2.0
-appVersion: 1.2.0
+version: 1.2.1
+appVersion: 1.2.1
 icon: https://raw.githubusercontent.com/caas-team/GoKubeDownscaler/refs/heads/main/logo/kubedownscaler.svg
 sources:
   - https://github.com/caas-team/GoKubeDownscaler


### PR DESCRIPTION
## Motivation

As stated in #175, we currently don't build an arm64 image inside the build-image workflow

## Changes

- Added `linux/arm64` inside the supported platforms of `docker_build.yaml`

## Tests Done

- Unit Tests