### PR TITLE
fix: role creation

### DIFF
--- a/deployments/chart/templates/role.yaml
+++ b/deployments/chart/templates/role.yaml
@@ -22,6 +22,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "go-kube-downscaler.serviceAccountName" $ }}
     namespace: {{ $.Release.Namespace }}
+---
 
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Motivation
When testing constrained namespaces with running `helm template ./deployments/chart/` i came across a similar problem as https://github.com/caas-team/py-kube-downscaler/issues/147 :
```yaml
---
# Source: go-kube-downscaler/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: release-name-go-kube-downscaler
  namespace: default
---
# Source: go-kube-downscaler/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: go-kube-downscaler
  namespace: default
data:
  EXCLUDE_NAMESPACES: 'kube-downscaler,kube-system'
---
# Source: go-kube-downscaler/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: release-name-go-kube-downscaler
  namespace: test
rules:
- apiGroups:
    - ""
  resources:
    - namespaces
  verbs:
    - get
- apiGroups:
    - ""
  resources:
    - events
  verbs:
    - get
    - create
    - update
- apiGroups:
    - apps
  resources:
    - deployments
  verbs:
    - get
    - list
    - update
---
# Source: go-kube-downscaler/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: release-name-go-kube-downscaler
  namespace: test
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: release-name-go-kube-downscaler
subjects:
  - kind: ServiceAccount
    name: release-name-go-kube-downscaler
    namespace: default
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: release-name-go-kube-downscaler
  namespace: test1
rules:
- apiGroups:
    - ""
  resources:
    - namespaces
  verbs:
    - get
- apiGroups:
    - ""
  resources:
    - events
  verbs:
    - get
    - create
    - update
- apiGroups:
    - apps
  resources:
    - deployments
  verbs:
    - get
    - list
    - update
---
# Source: go-kube-downscaler/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: release-name-go-kube-downscaler
  namespace: test1
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: release-name-go-kube-downscaler
subjects:
  - kind: ServiceAccount
    name: release-name-go-kube-downscaler
    namespace: default
---
# Source: go-kube-downscaler/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-go-kube-downscaler
  namespace: default
  labels:
    helm.sh/chart: go-kube-downscaler-1.2.1
    application: release-name-go-kube-downscaler
    app.kubernetes.io/version: "1.2.1"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      application: release-name-go-kube-downscaler
  template:
    metadata:
      labels:
        application: release-name-go-kube-downscaler
      annotations:
        checksum/config: 5f31b406b818769984033a59208447ade70ac956e68fc0104e90c68bf5888e21
    spec:
      serviceAccountName: release-name-go-kube-downscaler
      containers:
        - name: go-kube-downscaler
          image: "ghcr.io/caas-team/gokubedownscaler:1.2.1"
          args:
          - --include-resources=deployments
          - --namespace=test,test1
          envFrom:
          - configMapRef:
              name: go-kube-downscaler
              optional: true
          resources:
            limits:
              cpu: 2000m
              memory: 900Mi
            requests:
              cpu: 200m
              memory: 300Mi
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
          imagePullPolicy: IfNotPresent
      securityContext:
        fsGroup: 1000
        runAsGroup: 1000
        runAsNonRoot: true
        runAsUser: 1000
        supplementalGroups:
        - 1000
```

The separator is missing between the first RoleBinding and the second Role.
<!--
Explain briefly what this change aims to achieve and why it is important to do so.
Please keep this description updated with any discussion that takes place so
that reviewers can understand your intent. Keeping the description updated is
especially important if they didn't participate in the discussion.
-->

## Changes
- Added separator at the end of the role.yaml file
<!--
List the changes made to the code base. Per default, all commits are listed here.
Please keep this description updated as you add new changes to the PR.
-->

## Tests Done
Ran the template again afterwards:
```yaml
---
# Source: go-kube-downscaler/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: release-name-go-kube-downscaler
  namespace: default
---
# Source: go-kube-downscaler/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: go-kube-downscaler
  namespace: default
data:
  EXCLUDE_NAMESPACES: 'kube-downscaler,kube-system'
---
# Source: go-kube-downscaler/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: release-name-go-kube-downscaler
  namespace: test
rules:
- apiGroups:
    - ""
  resources:
    - namespaces
  verbs:
    - get
- apiGroups:
    - ""
  resources:
    - events
  verbs:
    - get
    - create
    - update
- apiGroups:
    - apps
  resources:
    - deployments
  verbs:
    - get
    - list
    - update
---
# Source: go-kube-downscaler/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: release-name-go-kube-downscaler
  namespace: test1
rules:
- apiGroups:
    - ""
  resources:
    - namespaces
  verbs:
    - get
- apiGroups:
    - ""
  resources:
    - events
  verbs:
    - get
    - create
    - update
- apiGroups:
    - apps
  resources:
    - deployments
  verbs:
    - get
    - list
    - update
---
# Source: go-kube-downscaler/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: release-name-go-kube-downscaler
  namespace: test
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: release-name-go-kube-downscaler
subjects:
  - kind: ServiceAccount
    name: release-name-go-kube-downscaler
    namespace: default
---
# Source: go-kube-downscaler/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: release-name-go-kube-downscaler
  namespace: test1
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: release-name-go-kube-downscaler
subjects:
  - kind: ServiceAccount
    name: release-name-go-kube-downscaler
    namespace: default
---
# Source: go-kube-downscaler/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-go-kube-downscaler
  namespace: default
  labels:
    helm.sh/chart: go-kube-downscaler-1.2.1
    application: release-name-go-kube-downscaler
    app.kubernetes.io/version: "1.2.1"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      application: release-name-go-kube-downscaler
  template:
    metadata:
      labels:
        application: release-name-go-kube-downscaler
      annotations:
        checksum/config: 5f31b406b818769984033a59208447ade70ac956e68fc0104e90c68bf5888e21
    spec:
      serviceAccountName: release-name-go-kube-downscaler
      containers:
        - name: go-kube-downscaler
          image: "ghcr.io/caas-team/gokubedownscaler:1.2.1"
          args:
          - --include-resources=deployments
          - --namespace=test,test1
          envFrom:
          - configMapRef:
              name: go-kube-downscaler
              optional: true
          resources:
            limits:
              cpu: 2000m
              memory: 900Mi
            requests:
              cpu: 200m
              memory: 300Mi
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
          imagePullPolicy: IfNotPresent
      securityContext:
        fsGroup: 1000
        runAsGroup: 1000
        runAsNonRoot: true
        runAsUser: 1000
        supplementalGroups:
        - 1000
```
<!--
List the tests that were done to verify the changes.
-->



<!--
List the things that still need to be done.
-->
