### PR TITLE
fix: deployment permissions

### DIFF
--- a/.github/workflows/deploy_website.yaml
+++ b/.github/workflows/deploy_website.yaml
@@ -34,7 +34,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     permissions:
-      pages: write
+      deployments: write
 
     steps:
       - name: Delete deployment


### PR DESCRIPTION
## Motivation
The cleanup of the deployment failed since it didn't have the right permissions.
<!--
Explain briefly what this change aims to achieve and why it is important to do so.
Please keep this description updated with any discussion that takes place so
that reviewers can understand your intent. Keeping the description updated is
especially important if they didn't participate in the discussion.
-->

## Changes
- changed permissions to `deployments: write` for cleanup
<!--
List the changes made to the code base. Per default, all commits are listed here.
Please keep this description updated as you add new changes to the PR.
-->



<!--
List the tests that were done to verify the changes.
-->



<!--
List the things that still need to be done.
-->
