### PR TITLE
fix: pre commit issues after updating linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -69,7 +69,7 @@ linters:
     - nilnesserr
     - nilnil
     #- nlreturn # wsl has a better implementation of the same principle, where you only have to put whitespaces if the block is longer
-    - noctx
+    #- noctx # we should re-enable this after we implement issue #125 to refactor the logging
     - nolintlint
     - nonamedreturns
     - nosprintfhostport
@@ -103,9 +103,15 @@ linters:
     - wastedassign
     - whitespace
     - wrapcheck
-    - wsl
+    - wsl_v5
     - zerologlint
   settings:
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
+      disable:
+        - decl
     ireturn:
       allow:
         - Replicas
@@ -180,8 +186,6 @@ linters:
         - name: unexported-return
           disabled: true
         - name: unused-parameter
-    wsl:
-      allow-cuddle-declarations: true
   exclusions:
     generated: lax
     presets:

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -248,7 +248,6 @@ func attemptScaling(
 	return newMaxRetriesExceeded(config.MaxRetriesOnConflict)
 }
 
-// nolint: cyclop // it is a big function and we can refactor it a bit but it should be fine for now
 // scanWorkload runs a scan on the worklod, determining the scaling and scaling the workload.
 func scanWorkload(
 	workload scalable.Workload,
@@ -261,6 +260,7 @@ func scanWorkload(
 	resourceLogger := kubernetes.NewResourceLoggerForWorkload(client, workload)
 
 	var err error
+
 	slog.Debug(
 		"parsing workload scope from annotations",
 		"annotations", workload.GetAnnotations(),

--- a/internal/pkg/scalable/cronjobs.go
+++ b/internal/pkg/scalable/cronjobs.go
@@ -54,7 +54,9 @@ func (c *cronJob) GetChildren(ctx context.Context, clientsets *Clientsets) ([]Wo
 			}
 
 			mutex.Lock()
+
 			results = append(results, &suspendScaledWorkload{&job{singleJob}})
+
 			mutex.Unlock()
 		}(activeJob)
 	}

--- a/internal/pkg/scalable/poddisruptionbudgets.go
+++ b/internal/pkg/scalable/poddisruptionbudgets.go
@@ -36,8 +36,6 @@ func (p *podDisruptionBudget) AllowPercentageReplicas() bool {
 }
 
 // getMinAvailable returns the spec.MinAvailable value or an undefined/empty value.
-//
-// nolint: gocritic // unnamedResult: function returns unnamed result values intentionally
 func (p *podDisruptionBudget) getMinAvailable() values.Replicas {
 	minAvailable := p.Spec.MinAvailable
 	if minAvailable == nil {
@@ -55,8 +53,6 @@ func (p *podDisruptionBudget) setMinAvailable(targetMinAvailable values.Replicas
 }
 
 // getMaxUnavailable returns the spec.MaxUnavailable value or an undefined/empty value.
-//
-// nolint: gocritic // unnamedResult: function returns unnamed result values intentionally
 func (p *podDisruptionBudget) getMaxUnavailable() values.Replicas {
 	maxUnavailable := p.Spec.MaxUnavailable
 	if maxUnavailable == nil {
@@ -105,7 +101,6 @@ func (p *podDisruptionBudget) ScaleUp() error {
 }
 
 // ScaleDown scales the resource down.
-// nolint:cyclop // this function is too complex, but it is necessary to handle workload types. We should refactor this in the future.
 func (p *podDisruptionBudget) ScaleDown(downscaleReplicas values.Replicas) error {
 	maxUnavailable := p.getMaxUnavailable()
 	if maxUnavailable != nil {

--- a/internal/pkg/scalable/replicaScaledWorkloads.go
+++ b/internal/pkg/scalable/replicaScaledWorkloads.go
@@ -26,7 +26,6 @@ type replicaScaledWorkload struct {
 }
 
 // ScaleUp scales up the underlying replicaScaledResource.
-// nolint: err113 // dynamic errors
 func (r *replicaScaledWorkload) ScaleUp() error {
 	originalReplicas, err := getOriginalReplicas(r)
 	if err != nil {
@@ -55,7 +54,6 @@ func (r *replicaScaledWorkload) ScaleUp() error {
 }
 
 // ScaleDown scales down the underlying replicaScaledResource.
-// nolint: err113 // dynamic errors
 func (r *replicaScaledWorkload) ScaleDown(downscaleReplicas values.Replicas) error {
 	downscaleReplicasInt32, err := downscaleReplicas.AsInt32()
 	if err != nil {

--- a/internal/pkg/values/replicas.go
+++ b/internal/pkg/values/replicas.go
@@ -43,7 +43,6 @@ type ReplicasValue struct {
 	Replicas *Replicas
 }
 
-// nolint: err113 // this is a value type, not a pointer
 func (r *ReplicasValue) Set(value string) error {
 	if v, err := strconv.ParseInt(value, 10, 32); err == nil {
 		replica := AbsoluteReplicas(int32(v))


### PR DESCRIPTION
## Motivation

<!--
Explain briefly what this change aims to achieve and why it is important to do so.
Please keep this description updated with any discussion that takes place so
that reviewers can understand your intent. Keeping the description updated is
especially important if they didn't participate in the discussion.
-->
This pr fixes the issues pre commit complains about after golangci lint got an update. The noctx linter was disabled since we adding contexts to all logger calls will get refactored by #125 soon. After we implement that issue the linter should be re-enabled

## Changes

<!--
List the changes made to the code base. Per default, all commits are listed here.
Please keep this description updated as you add new changes to the PR.
-->

## Tests Done

<!--
List the tests that were done to verify the changes.
-->

## TODO

<!--
List the things that still need to be done.
-->
