### PR TITLE
Feat/expose prometheus metrics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 fail_fast: true
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
         exclude: '\.(json)$'
@@ -9,7 +9,7 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, main]
   - repo: https://github.com/tekwizely/pre-commit-golang
-    rev: v1.0.0-rc.1
+    rev: v1.0.0-rc.2
     hooks:
       - id: go-mod-tidy-repo
       - id: go-test-repo-mod

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -14,11 +15,14 @@ import (
 	_ "time/tzdata"
 
 	"github.com/caas-team/gokubedownscaler/internal/api/kubernetes"
+	"github.com/caas-team/gokubedownscaler/internal/pkg/metrics"
 	"github.com/caas-team/gokubedownscaler/internal/pkg/scalable"
 	"github.com/caas-team/gokubedownscaler/internal/pkg/util"
 	"github.com/caas-team/gokubedownscaler/internal/pkg/values"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/component-base/metrics/legacyregistry"
 )
 
 const (
@@ -84,6 +88,32 @@ func main() {
 	runWithLeaderElection(client, cancel, ctx, scopeDefault, scopeCli, scopeEnv, config)
 }
 
+// serveMetrics starts the metrics server for the downscaler.
+func serveMetrics() {
+	pathRecorderMux := mux.NewPathRecorderMux("kube-downscaler")
+	metricsHandler := legacyregistry.Handler().ServeHTTP
+
+	pathRecorderMux.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
+		metricsHandler(w, req)
+	})
+
+	server := &http.Server{
+		Addr:         ":8085",
+		Handler:      pathRecorderMux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	err := server.ListenAndServe()
+	if err != nil {
+		slog.Error("failed to start metrics server", "error", err)
+		os.Exit(1)
+	}
+
+	slog.Info("serving metrics on /metrics")
+}
+
 // runWithLeaderElection runs the downscaler with leader election enabled.
 func runWithLeaderElection(
 	client kubernetes.Client,
@@ -114,8 +144,14 @@ func runWithLeaderElection(
 		RetryPeriod:     5 * time.Second,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
+				var downscalerMetrics *metrics.Metrics = nil
+				if scopeCli.MetricsEnabled {
+					go serveMetrics()
+					downscalerMetrics = metrics.NewMetrics()
+					downscalerMetrics.RegisterAll()
+				}
 				slog.Info("started leading")
-				err = startScanning(client, ctx, scopeDefault, scopeCli, scopeEnv, config)
+				err = startScanning(client, ctx, scopeDefault, scopeCli, scopeEnv, config, downscalerMetrics)
 				if err != nil {
 					slog.Error("an error occurred while scanning workloads", "error", err)
 					cancel()
@@ -141,7 +177,16 @@ func runWithoutLeaderElection(
 ) {
 	slog.Warn("proceeding without leader election; this could cause errors when running with multiple replicas")
 
-	err := startScanning(client, ctx, scopeDefault, scopeCli, scopeEnv, config)
+	var downscalerMetrics *metrics.Metrics = nil
+
+	if scopeCli.MetricsEnabled {
+		go serveMetrics()
+
+		downscalerMetrics = metrics.NewMetrics()
+		downscalerMetrics.RegisterAll()
+	}
+
+	err := startScanning(client, ctx, scopeDefault, scopeCli, scopeEnv, config, downscalerMetrics)
 	if err != nil {
 		slog.Error("an error occurred while scanning workloads, exiting", "error", err)
 		os.Exit(1)
@@ -154,11 +199,17 @@ func startScanning(
 	ctx context.Context,
 	scopeDefault, scopeCli, scopeEnv *values.Scope,
 	config *util.RuntimeConfiguration,
+	downscalerMetrics *metrics.Metrics,
 ) error {
 	slog.Info("started downscaler")
 
+	previousNamespacesToMetrics := make(map[string]*metrics.NamespaceMetricsHolder)
+
 	for {
 		slog.Info("scanning workloads")
+
+		start := time.Now()
+		currentNamespaceToMetrics := make(map[string]*metrics.NamespaceMetricsHolder)
 
 		workloads, err := client.GetWorkloads(config.IncludeNamespaces, config.IncludeResources, ctx)
 		if err != nil {
@@ -170,6 +221,7 @@ func startScanning(
 			config.IncludeLabels,
 			config.ExcludeNamespaces,
 			config.ExcludeWorkloads,
+			currentNamespaceToMetrics,
 		)
 		slog.Info("scanning over workloads matching filters", "amount", len(workloads))
 
@@ -187,7 +239,9 @@ func startScanning(
 
 				defer waitGroup.Done()
 
-				err := scanWorkload(workload, client, ctx, scopeDefault, scopeCli, scopeEnv, namespaceScopes, config)
+				workloadNamespaceMetrics := currentNamespaceToMetrics[workload.GetNamespace()]
+
+				err := scanWorkload(workload, client, ctx, scopeDefault, scopeCli, scopeEnv, namespaceScopes, workloadNamespaceMetrics, config)
 				if err != nil {
 					slog.Error("failed to scan workload", "error", err, "workload", workload.GetName(), "namespace", workload.GetNamespace())
 					return
@@ -205,6 +259,12 @@ func startScanning(
 			break
 		}
 
+		if scopeCli.MetricsEnabled {
+			downscalerMetrics.UpdateMetrics(currentNamespaceToMetrics, previousNamespacesToMetrics, time.Since(start).Seconds())
+		}
+
+		previousNamespacesToMetrics = currentNamespaceToMetrics
+
 		slog.Debug("waiting until next scan", "interval", config.Interval.String())
 		time.Sleep(config.Interval)
 	}
@@ -219,12 +279,14 @@ func attemptScaling(
 	scaling values.Scaling,
 	workload scalable.Workload,
 	scopes values.Scopes,
+	workloadNamespaceMetrics *metrics.NamespaceMetricsHolder,
 	config *util.RuntimeConfiguration,
 ) error {
 	for retry := range config.MaxRetriesOnConflict + 1 {
-		err := scaleWorkload(scaling, workload, scopes, client, ctx)
+		err := scaleWorkload(scaling, workload, scopes, workloadNamespaceMetrics, client, ctx)
 		if err != nil {
 			if !strings.Contains(err.Error(), registry.OptimisticLockErrorMsg) {
+				workloadNamespaceMetrics.IncrementGenericErrorsCount()
 				return fmt.Errorf("failed to scale workload: %w", err)
 			}
 
@@ -243,6 +305,7 @@ func attemptScaling(
 		return nil
 	}
 
+	workloadNamespaceMetrics.IncrementConflictErrorsCount()
 	slog.Error("failed to scale workload", "attempts", config.MaxRetriesOnConflict+1)
 
 	return newMaxRetriesExceeded(config.MaxRetriesOnConflict)
@@ -255,6 +318,7 @@ func scanWorkload(
 	ctx context.Context,
 	scopeDefault, scopeCli, scopeEnv *values.Scope,
 	namespaceScopes map[string]*values.Scope,
+	workloadNamespaceMetrics *metrics.NamespaceMetricsHolder,
 	config *util.RuntimeConfiguration,
 ) error {
 	resourceLogger := kubernetes.NewResourceLoggerForWorkload(client, workload)
@@ -290,22 +354,27 @@ func scanWorkload(
 		ctx,
 	)
 	if err != nil {
+		workloadNamespaceMetrics.IncrementExcludedWorkloadsCount()
 		return fmt.Errorf("failed to get if workload is on grace period: %w", err)
 	}
 
 	if isInGracePeriod {
 		slog.Debug("workload is on grace period, skipping", "workload", workload.GetName(), "namespace", workload.GetNamespace())
+		workloadNamespaceMetrics.IncrementExcludedWorkloadsCount()
+
 		return nil
 	}
 
 	if scopes.GetExcluded() {
 		slog.Debug("workload is excluded, skipping", "workload", workload.GetName(), "namespace", workload.GetNamespace())
+		workloadNamespaceMetrics.IncrementExcludedWorkloadsCount()
+
 		return nil
 	}
 
 	scaling := scopes.GetCurrentScaling()
 
-	err = attemptScaling(client, ctx, scaling, workload, scopes, config)
+	err = attemptScaling(client, ctx, scaling, workload, scopes, workloadNamespaceMetrics, config)
 	if err != nil {
 		return fmt.Errorf("failed to scale workload: %w", err)
 	}
@@ -316,7 +385,7 @@ func scanWorkload(
 			return fmt.Errorf("failed to get children workloads: %w", err)
 		}
 
-		scaleWorkloads(scaling, childrenWorkloads, scopes, client, ctx, config)
+		scaleWorkloads(scaling, childrenWorkloads, scopes, workloadNamespaceMetrics, client, ctx, config)
 	}
 
 	return nil
@@ -327,13 +396,14 @@ func scaleWorkloads(
 	scaling values.Scaling,
 	workloads []scalable.Workload,
 	scopes values.Scopes,
+	workloadNamespaceMetrics *metrics.NamespaceMetricsHolder,
 	client kubernetes.Client,
 	ctx context.Context,
 	config *util.RuntimeConfiguration,
 ) {
 	for _, workload := range workloads {
 		go func(workload scalable.Workload) {
-			err := attemptScaling(client, ctx, scaling, workload, scopes, config)
+			err := attemptScaling(client, ctx, scaling, workload, scopes, workloadNamespaceMetrics, config)
 			if err != nil {
 				slog.Error("failed to scale workload", "error", err, "workload", workload.GetName(), "namespace", workload.GetNamespace())
 			}
@@ -346,20 +416,27 @@ func scaleWorkload(
 	scaling values.Scaling,
 	workload scalable.Workload,
 	scopes values.Scopes,
+	workloadNamespaceMetrics *metrics.NamespaceMetricsHolder,
 	client kubernetes.Client,
 	ctx context.Context,
 ) error {
 	if scaling == values.ScalingNone {
 		slog.Debug("scaling is not set by any scope, skipping", "workload", workload.GetName(), "namespace", workload.GetNamespace())
+		workloadNamespaceMetrics.IncrementExcludedWorkloadsCount()
+
 		return nil
 	}
 
 	if scaling == values.ScalingIgnore {
 		slog.Debug("scaling is ignored, skipping", "workload", workload.GetName(), "namespace", workload.GetNamespace())
+		workloadNamespaceMetrics.IncrementExcludedWorkloadsCount()
+
 		return nil
 	}
 
 	if scaling == values.ScalingMultiple {
+		workloadNamespaceMetrics.IncrementInvalidScalingValueErrorsCount()
+
 		return newScalingInvalidError(
 			`scaling values matched to multiple states.
 this is the result of a faulty configuration where on a scope there is multiple values with the same priority
@@ -379,6 +456,8 @@ setting different scaling states at the same time (e.g. downtime-period and upti
 		if err != nil {
 			return fmt.Errorf("failed to downscale workload: %w", err)
 		}
+
+		workloadNamespaceMetrics.IncrementDownscaledWorkloadsCount()
 	}
 
 	if scaling == values.ScalingUp {
@@ -388,6 +467,8 @@ setting different scaling states at the same time (e.g. downtime-period and upti
 		if err != nil {
 			return fmt.Errorf("failed to upscale workload: %w", err)
 		}
+
+		workloadNamespaceMetrics.IncrementUpscaledWorkloadsCount()
 	}
 
 	return nil

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -145,9 +145,9 @@ func runWithLeaderElection(
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
 				var downscalerMetrics *metrics.Metrics = nil
-				if scopeCli.MetricsEnabled {
+				if config.MetricsEnabled {
 					go serveMetrics()
-					downscalerMetrics = metrics.NewMetrics()
+					downscalerMetrics = metrics.NewMetrics(config.DryRun)
 					downscalerMetrics.RegisterAll()
 				}
 				slog.Info("started leading")
@@ -179,10 +179,10 @@ func runWithoutLeaderElection(
 
 	var downscalerMetrics *metrics.Metrics = nil
 
-	if scopeCli.MetricsEnabled {
+	if config.MetricsEnabled {
 		go serveMetrics()
 
-		downscalerMetrics = metrics.NewMetrics()
+		downscalerMetrics = metrics.NewMetrics(config.DryRun)
 		downscalerMetrics.RegisterAll()
 	}
 
@@ -259,7 +259,7 @@ func startScanning(
 			break
 		}
 
-		if scopeCli.MetricsEnabled {
+		if config.MetricsEnabled && downscalerMetrics != nil {
 			downscalerMetrics.UpdateMetrics(currentNamespaceToMetrics, previousNamespacesToMetrics, time.Since(start).Seconds())
 		}
 
@@ -452,12 +452,14 @@ setting different scaling states at the same time (e.g. downtime-period and upti
 			return fmt.Errorf("failed to get downscale replicas: %w", err)
 		}
 
-		err = client.DownscaleWorkload(downscaleReplicas, workload, ctx)
+		totalSavedCPU, totalSavedMemory, err := client.DownscaleWorkload(downscaleReplicas, workload, ctx)
 		if err != nil {
 			return fmt.Errorf("failed to downscale workload: %w", err)
 		}
 
 		workloadNamespaceMetrics.IncrementDownscaledWorkloadsCount()
+		workloadNamespaceMetrics.IncrementSavedCPUCoresCount(totalSavedCPU)
+		workloadNamespaceMetrics.IncrementSavedMemoryBytesCount(totalSavedMemory)
 	}
 
 	if scaling == values.ScalingUp {

--- a/cmd/kubedownscaler/main_test.go
+++ b/cmd/kubedownscaler/main_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	client "github.com/caas-team/gokubedownscaler/internal/api/kubernetes"
+	"github.com/caas-team/gokubedownscaler/internal/pkg/metrics"
 	"github.com/caas-team/gokubedownscaler/internal/pkg/scalable"
 	"github.com/caas-team/gokubedownscaler/internal/pkg/util"
 	"github.com/caas-team/gokubedownscaler/internal/pkg/values"
@@ -81,6 +82,8 @@ func TestScanWorkload(t *testing.T) {
 		},
 	}
 
+	namespaceMetrics := &metrics.NamespaceMetricsHolder{}
+
 	mockClient := new(MockClient)
 	mockWorkload := new(MockWorkload)
 
@@ -92,7 +95,7 @@ func TestScanWorkload(t *testing.T) {
 	})
 	mockClient.On("DownscaleWorkload", values.AbsoluteReplicas(0), mockWorkload, ctx).Return(nil)
 
-	err := scanWorkload(mockWorkload, mockClient, ctx, values.GetDefaultScope(), scopeCli, scopeEnv, namespaceScopes, config)
+	err := scanWorkload(mockWorkload, mockClient, ctx, values.GetDefaultScope(), scopeCli, scopeEnv, namespaceScopes, namespaceMetrics, config)
 
 	require.NoError(t, err)
 

--- a/deployments/chart/templates/deployment.yaml
+++ b/deployments/chart/templates/deployment.yaml
@@ -36,8 +36,15 @@ spec:
           {{- if eq (include "go-kube-downscaler.leaderElection" .) "true" }}
           - --leader-election
           {{- end }}
+          {{- if .Values.metrics.enabled }}
+          - --metrics
+          {{- end }}
           {{- if .Values.constrainedNamespaces }}
           - --namespace={{ join "," .Values.constrainedNamespaces }}
+          {{- end }}
+          {{- if .Values.metrics.enabled }}
+          ports:
+            - containerPort: 8085
           {{- end }}
           envFrom:
           - configMapRef:

--- a/deployments/chart/templates/service.yaml
+++ b/deployments/chart/templates/service.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "go-kube-downscaler.fullname" . }}
+spec:
+  selector:
+    {{- include "go-kube-downscaler.selectorLabels" . | nindent 4 }}
+  ports:
+    - protocol: TCP
+      port: 8085
+      targetPort: 8085
+  type: ClusterIP
+{{- end }}

--- a/deployments/chart/values.yaml
+++ b/deployments/chart/values.yaml
@@ -29,9 +29,6 @@ nameOverride: ""
 
 constrainedNamespaces: []
 
-metrics:
-  enabled: true
-
 serviceAccount:
   create: true
   annotations: {}
@@ -84,3 +81,6 @@ configMap:
 
 # Force pod restart when the configuration changes
 forceRestartOnConfigChange: true
+
+metrics:
+  enabled: false

--- a/deployments/chart/values.yaml
+++ b/deployments/chart/values.yaml
@@ -29,6 +29,9 @@ nameOverride: ""
 
 constrainedNamespaces: []
 
+metrics:
+  enabled: true
+
 serviceAccount:
   create: true
   annotations: {}

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,14 @@ require (
 	github.com/kedacore/keda/v2 v2.17.2
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.84.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.84.0
+	github.com/prometheus/client_golang v1.22.0
 	github.com/stretchr/testify v1.10.0
 	github.com/zalando-incubator/stackset-controller v1.4.113
 	k8s.io/api v0.33.3
 	k8s.io/apimachinery v0.33.3
 	k8s.io/apiserver v0.33.3
 	k8s.io/client-go v0.33.3
+	k8s.io/component-base v0.33.3
 )
 
 require (
@@ -51,7 +53,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.16.0 // indirect
@@ -93,7 +94,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.33.2 // indirect
-	k8s.io/component-base v0.33.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250701173324-9bd5c66d9911 // indirect
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect

--- a/internal/pkg/metrics/metrics.go
+++ b/internal/pkg/metrics/metrics.go
@@ -1,0 +1,123 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	k8smetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	_ "k8s.io/component-base/metrics/prometheus/restclient"
+)
+
+const (
+	namespace                 = "namespace"
+	invalidScalingValueErrors = "invalid_scaling_value_errors"
+	conflictErrors            = "conflict_errors"
+	genericErrors             = "generic_errors"
+)
+
+type Metrics struct {
+	downscaledWorkloadGauge        *k8smetrics.GaugeVec
+	upscaledWorkloadGauge          *k8smetrics.GaugeVec
+	scalingErrorWorkloadGauge      *k8smetrics.GaugeVec
+	excludedWorkloadGauge          *k8smetrics.GaugeVec
+	savedMemoryGauge               *k8smetrics.GaugeVec
+	savedCPUGauge                  *k8smetrics.GaugeVec
+	downscalerCycleDurationSeconds *k8smetrics.Gauge
+	downscalerExecutionsTotal      *k8smetrics.Counter
+}
+
+func NewMetrics() *Metrics {
+	return &Metrics{
+		downscaledWorkloadGauge: k8smetrics.NewGaugeVec(
+			&k8smetrics.GaugeOpts{
+				Name: "kubedownscaler_downscaled_workloads",
+				Help: "Number of downscaled workloads managed by kubedownscaler broken down by namespace.",
+			}, []string{"namespace"},
+		),
+		upscaledWorkloadGauge: k8smetrics.NewGaugeVec(
+			&k8smetrics.GaugeOpts{
+				Name: "kubedownscaler_upscaled_workloads",
+				Help: "Number of upscaled workloads managed by kubedownscaler broken down by namespace.",
+			}, []string{"namespace"},
+		),
+		scalingErrorWorkloadGauge: k8smetrics.NewGaugeVec(
+			&k8smetrics.GaugeOpts{
+				Name: "kubedownscaler_scaling_errors",
+				Help: "Number of scaling errors encountered during the scale process.",
+			}, []string{"namespace", "type"},
+		),
+		excludedWorkloadGauge: k8smetrics.NewGaugeVec(
+			&k8smetrics.GaugeOpts{
+				Name: "kubedownscaler_excluded_workloads",
+				Help: "Number of workloads excluded from kubedownscaler management broken down by namespace.",
+			}, []string{"namespace"},
+		),
+		savedMemoryGauge: k8smetrics.NewGaugeVec(
+			&k8smetrics.GaugeOpts{
+				Name: "kubedownscaler_current_saved_memory_bytes",
+				Help: "Bytes of memory saved by kubedownscaler downscaling actions.",
+			}, []string{"namespace"},
+		),
+		savedCPUGauge: k8smetrics.NewGaugeVec(
+			&k8smetrics.GaugeOpts{
+				Name: "kubedownscaler_current_saved_cpu_cores",
+				Help: "Cores of cpu saved by kubedownscaler downscaling actions.",
+			}, []string{"namespace"},
+		),
+		downscalerCycleDurationSeconds: k8smetrics.NewGauge(
+			&k8smetrics.GaugeOpts{
+				Name: "kubedownscaler_cycle_duration_seconds",
+				Help: "Duration of kubedownscaler cycle in seconds.",
+			},
+		),
+		downscalerExecutionsTotal: k8smetrics.NewCounter(
+			&k8smetrics.CounterOpts{
+				Name: "kubedownscaler_cycle_executions_total",
+				Help: "Number of cycles completed by kubedownscaler since being instantiated.",
+			},
+		),
+	}
+}
+
+func (m *Metrics) RegisterAll() {
+	legacyregistry.MustRegister(m.downscaledWorkloadGauge)
+	legacyregistry.MustRegister(m.upscaledWorkloadGauge)
+	legacyregistry.MustRegister(m.excludedWorkloadGauge)
+	legacyregistry.MustRegister(m.scalingErrorWorkloadGauge)
+	legacyregistry.MustRegister(m.savedMemoryGauge)
+	legacyregistry.MustRegister(m.savedCPUGauge)
+	legacyregistry.MustRegister(m.downscalerCycleDurationSeconds)
+	legacyregistry.MustRegister(m.downscalerExecutionsTotal)
+}
+
+func (m *Metrics) UpdateMetrics(
+	currentNamespaceToMetrics map[string]*NamespaceMetricsHolder,
+	previousNamespacesToMetrics map[string]*NamespaceMetricsHolder,
+	cycleDuration float64,
+) {
+	for previousNamespace := range previousNamespacesToMetrics {
+		if _, exists := currentNamespaceToMetrics[previousNamespace]; exists {
+			continue
+		}
+
+		m.downscaledWorkloadGauge.DeleteLabelValues(previousNamespace)
+		m.upscaledWorkloadGauge.DeleteLabelValues(previousNamespace)
+		m.scalingErrorWorkloadGauge.DeletePartialMatch(prometheus.Labels{namespace: previousNamespace})
+		m.excludedWorkloadGauge.DeleteLabelValues(previousNamespace)
+		m.savedMemoryGauge.DeleteLabelValues(previousNamespace)
+		m.savedCPUGauge.DeleteLabelValues(previousNamespace)
+	}
+
+	for currentNamespace, metricsRecord := range currentNamespaceToMetrics {
+		m.downscaledWorkloadGauge.WithLabelValues(currentNamespace).Set(metricsRecord.DownscaledWorkloads())
+		m.upscaledWorkloadGauge.WithLabelValues(currentNamespace).Set(metricsRecord.UpscaledWorkloads())
+		m.excludedWorkloadGauge.WithLabelValues(currentNamespace).Set(metricsRecord.ExcludedWorkloads())
+		m.scalingErrorWorkloadGauge.WithLabelValues(currentNamespace, invalidScalingValueErrors).Set(metricsRecord.InvalidScalingValueErrors())
+		m.scalingErrorWorkloadGauge.WithLabelValues(currentNamespace, conflictErrors).Set(metricsRecord.ConflictErrors())
+		m.scalingErrorWorkloadGauge.WithLabelValues(currentNamespace, genericErrors).Set(metricsRecord.GenericErrors())
+		m.savedMemoryGauge.WithLabelValues(currentNamespace).Set(metricsRecord.SavedMemoryBytes())
+		m.savedCPUGauge.WithLabelValues(currentNamespace).Set(metricsRecord.SavedCPUCores())
+	}
+
+	m.downscalerCycleDurationSeconds.Set(cycleDuration)
+	m.downscalerExecutionsTotal.Inc()
+}

--- a/internal/pkg/metrics/namespaceMetricsHolder.go
+++ b/internal/pkg/metrics/namespaceMetricsHolder.go
@@ -10,6 +10,7 @@ type NamespaceMetricsHolder struct {
 	genericErrors             float64
 	savedMemoryBytes          float64
 	savedCPUcores             float64
+	dryRun                    bool
 }
 
 func (m *NamespaceMetricsHolder) DownscaledWorkloads() float64 {
@@ -45,15 +46,21 @@ func (m *NamespaceMetricsHolder) SavedCPUCores() float64 {
 }
 
 func (m *NamespaceMetricsHolder) IncrementDownscaledWorkloadsCount() {
-	m.downscaledWorkloads++
+	if !m.dryRun {
+		m.downscaledWorkloads++
+	}
 }
 
 func (m *NamespaceMetricsHolder) IncrementUpscaledWorkloadsCount() {
-	m.upscaledWorkloads++
+	if !m.dryRun {
+		m.upscaledWorkloads++
+	}
 }
 
 func (m *NamespaceMetricsHolder) IncrementExcludedWorkloadsCount() {
-	m.excludedWorkloads++
+	if !m.dryRun {
+		m.excludedWorkloads++
+	}
 }
 
 func (m *NamespaceMetricsHolder) IncrementInvalidScalingValueErrorsCount() {
@@ -69,9 +76,13 @@ func (m *NamespaceMetricsHolder) IncrementGenericErrorsCount() {
 }
 
 func (m *NamespaceMetricsHolder) IncrementSavedMemoryBytesCount(value float64) {
-	m.savedMemoryBytes += value
+	if !m.dryRun {
+		m.savedMemoryBytes += value
+	}
 }
 
 func (m *NamespaceMetricsHolder) IncrementSavedCPUCoresCount(value float64) {
-	m.savedCPUcores += value
+	if !m.dryRun {
+		m.savedCPUcores += value
+	}
 }

--- a/internal/pkg/metrics/namespaceMetricsHolder.go
+++ b/internal/pkg/metrics/namespaceMetricsHolder.go
@@ -1,0 +1,77 @@
+package metrics
+
+// NamespaceMetricsHolder holds the metrics for a specific namespace.
+type NamespaceMetricsHolder struct {
+	downscaledWorkloads       float64
+	upscaledWorkloads         float64
+	excludedWorkloads         float64
+	invalidScalingValueErrors float64
+	conflictErrors            float64
+	genericErrors             float64
+	savedMemoryBytes          float64
+	savedCPUcores             float64
+}
+
+func (m *NamespaceMetricsHolder) DownscaledWorkloads() float64 {
+	return m.downscaledWorkloads
+}
+
+func (m *NamespaceMetricsHolder) UpscaledWorkloads() float64 {
+	return m.upscaledWorkloads
+}
+
+func (m *NamespaceMetricsHolder) ExcludedWorkloads() float64 {
+	return m.excludedWorkloads
+}
+
+func (m *NamespaceMetricsHolder) InvalidScalingValueErrors() float64 {
+	return m.invalidScalingValueErrors
+}
+
+func (m *NamespaceMetricsHolder) ConflictErrors() float64 {
+	return m.conflictErrors
+}
+
+func (m *NamespaceMetricsHolder) GenericErrors() float64 {
+	return m.genericErrors
+}
+
+func (m *NamespaceMetricsHolder) SavedMemoryBytes() float64 {
+	return m.savedMemoryBytes
+}
+
+func (m *NamespaceMetricsHolder) SavedCPUCores() float64 {
+	return m.savedCPUcores
+}
+
+func (m *NamespaceMetricsHolder) IncrementDownscaledWorkloadsCount() {
+	m.downscaledWorkloads++
+}
+
+func (m *NamespaceMetricsHolder) IncrementUpscaledWorkloadsCount() {
+	m.upscaledWorkloads++
+}
+
+func (m *NamespaceMetricsHolder) IncrementExcludedWorkloadsCount() {
+	m.excludedWorkloads++
+}
+
+func (m *NamespaceMetricsHolder) IncrementInvalidScalingValueErrorsCount() {
+	m.invalidScalingValueErrors++
+}
+
+func (m *NamespaceMetricsHolder) IncrementConflictErrorsCount() {
+	m.conflictErrors++
+}
+
+func (m *NamespaceMetricsHolder) IncrementGenericErrorsCount() {
+	m.genericErrors++
+}
+
+func (m *NamespaceMetricsHolder) IncrementSavedMemoryBytesCount(value float64) {
+	m.savedMemoryBytes += value
+}
+
+func (m *NamespaceMetricsHolder) IncrementSavedCPUCoresCount(value float64) {
+	m.savedCPUcores += value
+}

--- a/internal/pkg/metrics/namespaceMetricsHolder.go
+++ b/internal/pkg/metrics/namespaceMetricsHolder.go
@@ -10,7 +10,6 @@ type NamespaceMetricsHolder struct {
 	genericErrors             float64
 	savedMemoryBytes          float64
 	savedCPUcores             float64
-	dryRun                    bool
 }
 
 func (m *NamespaceMetricsHolder) DownscaledWorkloads() float64 {
@@ -46,21 +45,15 @@ func (m *NamespaceMetricsHolder) SavedCPUCores() float64 {
 }
 
 func (m *NamespaceMetricsHolder) IncrementDownscaledWorkloadsCount() {
-	if !m.dryRun {
-		m.downscaledWorkloads++
-	}
+	m.downscaledWorkloads++
 }
 
 func (m *NamespaceMetricsHolder) IncrementUpscaledWorkloadsCount() {
-	if !m.dryRun {
-		m.upscaledWorkloads++
-	}
+	m.upscaledWorkloads++
 }
 
 func (m *NamespaceMetricsHolder) IncrementExcludedWorkloadsCount() {
-	if !m.dryRun {
-		m.excludedWorkloads++
-	}
+	m.excludedWorkloads++
 }
 
 func (m *NamespaceMetricsHolder) IncrementInvalidScalingValueErrorsCount() {
@@ -76,13 +69,9 @@ func (m *NamespaceMetricsHolder) IncrementGenericErrorsCount() {
 }
 
 func (m *NamespaceMetricsHolder) IncrementSavedMemoryBytesCount(value float64) {
-	if !m.dryRun {
-		m.savedMemoryBytes += value
-	}
+	m.savedMemoryBytes += value
 }
 
 func (m *NamespaceMetricsHolder) IncrementSavedCPUCoresCount(value float64) {
-	if !m.dryRun {
-		m.savedCPUcores += value
-	}
+	m.savedCPUcores += value
 }

--- a/internal/pkg/scalable/daemonsets_test.go
+++ b/internal/pkg/scalable/daemonsets_test.go
@@ -3,9 +3,12 @@ package scalable
 import (
 	"testing"
 
+	"github.com/caas-team/gokubedownscaler/internal/pkg/values"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestDaemonSet_ScaleUp(t *testing.T) {
@@ -51,19 +54,44 @@ func TestDaemonSet_ScaleDown(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		labelSet     bool
-		wantLabelSet bool
+		name             string
+		labelSet         bool
+		wantLabelSet     bool
+		currentScheduled int32
+		requestsCPU      string
+		requestsMemory   string
+		wantSavedCPU     float64
+		wantSavedMemory  float64
 	}{
 		{
-			name:         "scale down",
-			labelSet:     false,
-			wantLabelSet: true,
+			name:             "scale down",
+			labelSet:         false,
+			wantLabelSet:     true,
+			currentScheduled: 3,
+			requestsCPU:      "100m",    // 0.1 CPU
+			requestsMemory:   "200Mi",   // 200 MiB
+			wantSavedCPU:     0.3,       // 0.1 * 3
+			wantSavedMemory:  629145600, // 200Mi * 3
 		},
 		{
-			name:         "already scaled down",
-			labelSet:     true,
-			wantLabelSet: true,
+			name:             "already scaled down",
+			labelSet:         true,
+			wantLabelSet:     true,
+			currentScheduled: 2,
+			requestsCPU:      "50m",     // 0.05 CPU
+			requestsMemory:   "100Mi",   // 100 MiB
+			wantSavedCPU:     0.1,       // 0.05 * 2
+			wantSavedMemory:  209715200, // 100Mi * 2
+		},
+		{
+			name:             "scale down with no resource requests",
+			labelSet:         false,
+			wantLabelSet:     true,
+			currentScheduled: 2,
+			requestsCPU:      "",
+			requestsMemory:   "",
+			wantSavedCPU:     0.0,
+			wantSavedMemory:  0.0,
 		},
 	}
 
@@ -71,17 +99,37 @@ func TestDaemonSet_ScaleDown(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			deamonset := daemonSet{&appsv1.DaemonSet{}}
+			daemonset := daemonSet{&appsv1.DaemonSet{}}
+			daemonset.Status.CurrentNumberScheduled = test.currentScheduled
 
-			if test.labelSet {
-				deamonset.Spec.Template.Spec.NodeSelector = map[string]string{labelMatchNone: "true"}
+			// set container requests
+			if test.requestsCPU != "" || test.requestsMemory != "" {
+				reqs := corev1.ResourceList{}
+				if test.requestsCPU != "" {
+					reqs[corev1.ResourceCPU] = resource.MustParse(test.requestsCPU)
+				}
+
+				if test.requestsMemory != "" {
+					reqs[corev1.ResourceMemory] = resource.MustParse(test.requestsMemory)
+				}
+
+				daemonset.Spec.Template.Spec.Containers = []corev1.Container{
+					{Resources: corev1.ResourceRequirements{Requests: reqs}},
+				}
 			}
 
-			err := deamonset.ScaleDown(nil)
+			if test.labelSet {
+				daemonset.Spec.Template.Spec.NodeSelector = map[string]string{labelMatchNone: "true"}
+			}
+
+			totalSavedCPU, totalSavedMemory, err := daemonset.ScaleDown(values.AbsoluteReplicas(0))
 			require.NoError(t, err)
 
-			_, ok := deamonset.Spec.Template.Spec.NodeSelector[labelMatchNone]
+			_, ok := daemonset.Spec.Template.Spec.NodeSelector[labelMatchNone]
 			assert.Equal(t, test.wantLabelSet, ok)
+
+			assert.InDelta(t, test.wantSavedCPU, totalSavedCPU, 0.0001)
+			assert.InDelta(t, test.wantSavedMemory, totalSavedMemory, 1e5)
 		})
 	}
 }

--- a/internal/pkg/scalable/horizontalpodautoscalers.go
+++ b/internal/pkg/scalable/horizontalpodautoscalers.go
@@ -66,6 +66,13 @@ func (h *horizontalPodAutoscaler) Reget(clientsets *Clientsets, ctx context.Cont
 	return nil
 }
 
+// getSavedResourcesRequests calculates the total saved resources requests when downscaling the HorizontalPodAutoscaler.
+//
+//nolint:nonamedreturns // using named return values for clarity and to simplify return statements
+func (h *horizontalPodAutoscaler) getSavedResourcesRequests(_ int32) (totalSavedCPU, totalSavedMemory float64) {
+	return totalSavedCPU, totalSavedMemory
+}
+
 // Update updates the resource with all changes made to it. It should only be called once on a resource.
 func (h *horizontalPodAutoscaler) Update(clientsets *Clientsets, ctx context.Context) error {
 	_, err := clientsets.Kubernetes.AutoscalingV2().HorizontalPodAutoscalers(h.Namespace).Update(

--- a/internal/pkg/scalable/poddisruptionbudgets.go
+++ b/internal/pkg/scalable/poddisruptionbudgets.go
@@ -101,34 +101,36 @@ func (p *podDisruptionBudget) ScaleUp() error {
 }
 
 // ScaleDown scales the resource down.
-func (p *podDisruptionBudget) ScaleDown(downscaleReplicas values.Replicas) error {
+//
+//nolint:nonamedreturns // using named return values for clarity and to simplify return statements
+func (p *podDisruptionBudget) ScaleDown(downscaleReplicas values.Replicas) (totalSavedCPU, totalSavedMemory float64, err error) {
 	maxUnavailable := p.getMaxUnavailable()
 	if maxUnavailable != nil {
 		if maxUnavailable.String() == downscaleReplicas.String() {
 			slog.Debug("workload is already scaled down, skipping", "workload", p.GetName(), "namespace", p.GetNamespace())
-			return nil
+			return totalSavedCPU, totalSavedMemory, nil
 		}
 
 		p.setMaxUnavailable(downscaleReplicas)
 		setOriginalReplicas(maxUnavailable, p)
 
-		return nil
+		return totalSavedCPU, totalSavedMemory, nil
 	}
 
 	minAvailable := p.getMinAvailable()
 	if minAvailable != nil {
 		if minAvailable.String() == downscaleReplicas.String() {
 			slog.Debug("workload is already scaled down, skipping", "workload", p.GetName(), "namespace", p.GetNamespace())
-			return nil
+			return totalSavedCPU, totalSavedMemory, nil
 		}
 
 		p.setMinAvailable(downscaleReplicas)
 		setOriginalReplicas(minAvailable, p)
 
-		return nil
+		return totalSavedCPU, totalSavedMemory, nil
 	}
 
-	return nil
+	return totalSavedCPU, totalSavedMemory, nil
 }
 
 // Reget regets the resource from the Kubernetes API.

--- a/internal/pkg/scalable/poddisruptionbudgets_test.go
+++ b/internal/pkg/scalable/poddisruptionbudgets_test.go
@@ -279,7 +279,7 @@ func TestPodDisruptionBudget_ScaleDown(t *testing.T) {
 				setOriginalReplicas(test.originalReplicas, pdb)
 			}
 
-			err := pdb.ScaleDown(values.AbsoluteReplicas(0))
+			_, _, err := pdb.ScaleDown(values.AbsoluteReplicas(0))
 			require.NoError(t, err)
 
 			if test.wantMaxUnavailable != nil {

--- a/internal/pkg/scalable/prometheuses.go
+++ b/internal/pkg/scalable/prometheuses.go
@@ -57,6 +57,24 @@ func (p *prometheus) Reget(clientsets *Clientsets, ctx context.Context) error {
 	return nil
 }
 
+// getSavedResourcesRequests calculates the total saved resources requests when downscaling the Prometheus.
+//
+//nolint:nonamedreturns // using named return values for clarity and to simplify return statements
+func (p *prometheus) getSavedResourcesRequests(downscaleReplicas int32) (totalSavedCPU, totalSavedMemory float64) {
+	for i := range p.Spec.Containers {
+		container := &p.Spec.Containers[i] // take pointer to avoid copying
+		if container.Resources.Requests != nil {
+			totalSavedCPU += container.Resources.Requests.Cpu().AsApproximateFloat64()
+			totalSavedMemory += container.Resources.Requests.Memory().AsApproximateFloat64()
+		}
+	}
+
+	totalSavedCPU *= float64(*p.Spec.Replicas - downscaleReplicas)
+	totalSavedMemory *= float64(*p.Spec.Replicas - downscaleReplicas)
+
+	return totalSavedCPU, totalSavedMemory
+}
+
 // Update updates the resource with all changes made to it. It should only be called once on a resource.
 func (p *prometheus) Update(clientsets *Clientsets, ctx context.Context) error {
 	_, err := clientsets.Monitoring.MonitoringV1().Prometheuses(p.Namespace).Update(ctx, p.Prometheus, metav1.UpdateOptions{})

--- a/internal/pkg/scalable/scaledobjects.go
+++ b/internal/pkg/scalable/scaledobjects.go
@@ -80,6 +80,13 @@ func (s *scaledObject) Reget(clientsets *Clientsets, ctx context.Context) error 
 	return nil
 }
 
+// getSavedResourcesRequests returns the total saved CPU and memory requests for the scaled object.
+//
+//nolint:nonamedreturns // using named return values for clarity and to simplify return statements
+func (s *scaledObject) getSavedResourcesRequests(_ int32) (totalSavedCPU, totalSavedMemory float64) {
+	return totalSavedCPU, totalSavedMemory
+}
+
 // Update updates the resource with all changes made to it. It should only be called once on a resource.
 func (s *scaledObject) Update(clientsets *Clientsets, ctx context.Context) error {
 	_, err := clientsets.Keda.KedaV1alpha1().ScaledObjects(s.Namespace).Update(ctx, s.ScaledObject, metav1.UpdateOptions{})

--- a/internal/pkg/scalable/suspendScaledWorkloads.go
+++ b/internal/pkg/scalable/suspendScaledWorkloads.go
@@ -13,6 +13,8 @@ type suspendScaledResource interface {
 	Update(clientsets *Clientsets, ctx context.Context) error
 	// setSuspend sets the value of the suspend field on the workload
 	setSuspend(suspend bool)
+	// getSavedResourcesRequests returns the saved CPU and memory requests for the workload based on the downscale replicas.
+	getSavedResourcesRequests() (float64, float64)
 }
 
 // suspendScaledWorkload is a wrapper for all resources which are scaled by setting a suspend field.
@@ -27,7 +29,12 @@ func (r *suspendScaledWorkload) ScaleUp() error {
 }
 
 // ScaleDown scales down the underlying suspendScaledResource.
-func (r *suspendScaledWorkload) ScaleDown(_ values.Replicas) error {
+//
+//nolint:nonamedreturns // using named return values for clarity and to simplify return statements
+func (r *suspendScaledWorkload) ScaleDown(_ values.Replicas) (totalSavedCPU, totalSavedMemory float64, err error) {
+	totalSavedCPU, totalSavedMemory = r.getSavedResourcesRequests()
+
 	r.setSuspend(true)
-	return nil
+
+	return totalSavedCPU, totalSavedMemory, nil
 }

--- a/internal/pkg/scalable/suspendScaledWorkloads_test.go
+++ b/internal/pkg/scalable/suspendScaledWorkloads_test.go
@@ -3,8 +3,11 @@ package scalable
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	batch "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestSuspendScaledWorkload_ScaleUp(t *testing.T) {
@@ -51,24 +54,44 @@ func TestSuspendScaledWorkload_ScaleDown(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		suspend     *bool
-		wantSuspend *bool
+		name            string
+		suspend         *bool
+		parallelism     int32
+		cpuRequest      string
+		memRequest      string
+		wantSuspend     *bool
+		wantSavedCPU    float64
+		wantSavedMemory float64
 	}{
 		{
-			name:        "scale down",
-			suspend:     boolAsPointer(false),
-			wantSuspend: boolAsPointer(true),
+			name:            "scale down",
+			suspend:         boolAsPointer(false),
+			parallelism:     2,
+			cpuRequest:      "250m",
+			memRequest:      "128Mi",
+			wantSuspend:     boolAsPointer(true),
+			wantSavedCPU:    0.25 * 2,              // 250m * 2
+			wantSavedMemory: 128 * 1024 * 1024 * 2, // 128Mi * 2
 		},
 		{
-			name:        "already scaled down",
-			suspend:     boolAsPointer(true),
-			wantSuspend: boolAsPointer(true),
+			name:            "already scaled down",
+			suspend:         boolAsPointer(true),
+			parallelism:     2,
+			cpuRequest:      "250m",
+			memRequest:      "128Mi",
+			wantSuspend:     boolAsPointer(true),
+			wantSavedCPU:    0.25 * 2,
+			wantSavedMemory: 128 * 1024 * 1024 * 2,
 		},
 		{
-			name:        "suspend unset",
-			suspend:     nil,
-			wantSuspend: boolAsPointer(true),
+			name:            "suspend unset",
+			suspend:         nil,
+			parallelism:     2,
+			cpuRequest:      "250m",
+			memRequest:      "128Mi",
+			wantSuspend:     boolAsPointer(true),
+			wantSavedCPU:    0.25 * 2,
+			wantSavedMemory: 128 * 1024 * 1024 * 2,
 		},
 	}
 
@@ -78,11 +101,26 @@ func TestSuspendScaledWorkload_ScaleDown(t *testing.T) {
 
 			cronjob := cronJob{&batch.CronJob{}}
 			cronjob.Spec.Suspend = test.suspend
+			cronjob.Spec.JobTemplate.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse(test.cpuRequest),
+							corev1.ResourceMemory: resource.MustParse(test.memRequest),
+						},
+					},
+				},
+			}
+			cronjob.Spec.JobTemplate.Spec.Parallelism = &test.parallelism
+
 			s := suspendScaledWorkload{&cronjob}
 
-			err := s.ScaleDown(nil)
+			totalSavedCPU, totalSavedMemory, err := s.ScaleDown(nil)
 			require.NoError(t, err)
+
 			assertBoolPointerEqual(t, test.wantSuspend, cronjob.Spec.Suspend)
+			assert.InDelta(t, test.wantSavedCPU, totalSavedCPU, 0.0001)
+			assert.InDelta(t, test.wantSavedMemory, totalSavedMemory, 1e5)
 		})
 	}
 }

--- a/internal/pkg/scalable/util.go
+++ b/internal/pkg/scalable/util.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/caas-team/gokubedownscaler/internal/pkg/metrics"
 	"github.com/caas-team/gokubedownscaler/internal/pkg/util"
 	"github.com/caas-team/gokubedownscaler/internal/pkg/values"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -19,6 +20,7 @@ func FilterExcluded(
 	includeLabels,
 	excludedNamespaces,
 	excludedWorkloads util.RegexList,
+	currentNamespaceToMetrics map[string]*metrics.NamespaceMetricsHolder,
 ) []Workload {
 	externallyScaled := getExternallyScaled(workloads)
 
@@ -31,6 +33,7 @@ func FilterExcluded(
 				"workload", workload.GetName(),
 				"namespace", workload.GetNamespace(),
 			)
+			currentNamespaceToMetrics[workload.GetNamespace()].IncrementDownscaledWorkloadsCount()
 
 			continue
 		}
@@ -41,6 +44,7 @@ func FilterExcluded(
 				"workload", workload.GetName(),
 				"namespace", workload.GetNamespace(),
 			)
+			currentNamespaceToMetrics[workload.GetNamespace()].IncrementExcludedWorkloadsCount()
 
 			continue
 		}
@@ -51,6 +55,7 @@ func FilterExcluded(
 				"workload", workload.GetName(),
 				"namespace", workload.GetNamespace(),
 			)
+			currentNamespaceToMetrics[workload.GetNamespace()].IncrementExcludedWorkloadsCount()
 
 			continue
 		}
@@ -61,6 +66,7 @@ func FilterExcluded(
 				"workload", workload.GetName(),
 				"namespace", workload.GetNamespace(),
 			)
+			currentNamespaceToMetrics[workload.GetNamespace()].IncrementExcludedWorkloadsCount()
 
 			continue
 		}

--- a/internal/pkg/scalable/util_test.go
+++ b/internal/pkg/scalable/util_test.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/caas-team/gokubedownscaler/internal/pkg/metrics"
 	"github.com/caas-team/gokubedownscaler/internal/pkg/util"
 	"github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -127,12 +128,13 @@ func TestFilterExcluded(t *testing.T) {
 	}
 
 	tests := []struct {
-		name               string
-		workloads          []Workload
-		includeLabels      util.RegexList
-		excludedNamespaces util.RegexList
-		excludedWorkloads  util.RegexList
-		want               []Workload
+		name                      string
+		workloads                 []Workload
+		includeLabels             util.RegexList
+		excludedNamespaces        util.RegexList
+		excludedWorkloads         util.RegexList
+		currentNamespaceToMetrics map[string]*metrics.NamespaceMetricsHolder
+		want                      []Workload
 	}{
 		{
 			name:               "none set",
@@ -140,7 +142,12 @@ func TestFilterExcluded(t *testing.T) {
 			includeLabels:      nil,
 			excludedNamespaces: nil,
 			excludedWorkloads:  nil,
-			want:               []Workload{ns1.deployment1, ns1.deployment2, ns2.deployment1},
+			currentNamespaceToMetrics: map[string]*metrics.NamespaceMetricsHolder{
+				"Namespace1": {},
+				"Namespace2": {},
+				"Namespace3": {},
+			},
+			want: []Workload{ns1.deployment1, ns1.deployment2, ns2.deployment1},
 		},
 		{
 			name:               "includeLabels",
@@ -148,7 +155,12 @@ func TestFilterExcluded(t *testing.T) {
 			includeLabels:      util.RegexList{regexp.MustCompile(".*")}, // match any label
 			excludedNamespaces: nil,
 			excludedWorkloads:  nil,
-			want:               []Workload{ns1.labeledDeployment},
+			currentNamespaceToMetrics: map[string]*metrics.NamespaceMetricsHolder{
+				"Namespace1": {},
+				"Namespace2": {},
+				"Namespace3": {},
+			},
+			want: []Workload{ns1.labeledDeployment},
 		},
 		{
 			name:               "excludeNamespaces",
@@ -156,7 +168,12 @@ func TestFilterExcluded(t *testing.T) {
 			includeLabels:      nil,
 			excludedNamespaces: util.RegexList{regexp.MustCompile("Namespace1")}, // exclude Namespace1
 			excludedWorkloads:  nil,
-			want:               []Workload{ns2.deployment1},
+			currentNamespaceToMetrics: map[string]*metrics.NamespaceMetricsHolder{
+				"Namespace1": {},
+				"Namespace2": {},
+				"Namespace3": {},
+			},
+			want: []Workload{ns2.deployment1},
 		},
 		{
 			name:               "excludeWorkloads",
@@ -164,7 +181,12 @@ func TestFilterExcluded(t *testing.T) {
 			includeLabels:      nil,
 			excludedNamespaces: nil,
 			excludedWorkloads:  util.RegexList{regexp.MustCompile("Deployment1")}, // exclude Deployment1
-			want:               []Workload{ns1.deployment2},
+			currentNamespaceToMetrics: map[string]*metrics.NamespaceMetricsHolder{
+				"Namespace1": {},
+				"Namespace2": {},
+				"Namespace3": {},
+			},
+			want: []Workload{ns1.deployment2},
 		},
 		{
 			name:               "exclude scaled object scaled",
@@ -172,7 +194,12 @@ func TestFilterExcluded(t *testing.T) {
 			includeLabels:      nil,
 			excludedNamespaces: nil,
 			excludedWorkloads:  nil,
-			want:               []Workload{ns3.deployment1, ns3.scaledObject, ns1.deployment1, ns1.deployment2, ns2.deployment1},
+			currentNamespaceToMetrics: map[string]*metrics.NamespaceMetricsHolder{
+				"Namespace1": {},
+				"Namespace2": {},
+				"Namespace3": {},
+			},
+			want: []Workload{ns3.deployment1, ns3.scaledObject, ns1.deployment1, ns1.deployment2, ns2.deployment1},
 		},
 		{
 			name:               "exclude managed by ownerReference",
@@ -180,7 +207,12 @@ func TestFilterExcluded(t *testing.T) {
 			includeLabels:      nil,
 			excludedNamespaces: nil,
 			excludedWorkloads:  nil,
-			want:               []Workload{ns3.deployment1, ns3.scaledObject, ns1.deployment1, ns3.job2},
+			currentNamespaceToMetrics: map[string]*metrics.NamespaceMetricsHolder{
+				"Namespace1": {},
+				"Namespace2": {},
+				"Namespace3": {},
+			},
+			want: []Workload{ns3.deployment1, ns3.scaledObject, ns1.deployment1, ns3.job2},
 		},
 	}
 
@@ -193,6 +225,7 @@ func TestFilterExcluded(t *testing.T) {
 				test.includeLabels,
 				test.excludedNamespaces,
 				test.excludedWorkloads,
+				test.currentNamespaceToMetrics,
 			)
 
 			assert.Equal(t, test.want, got)

--- a/internal/pkg/scalable/workload.go
+++ b/internal/pkg/scalable/workload.go
@@ -87,7 +87,7 @@ type Workload interface {
 	// ScaleUp scales up the workload
 	ScaleUp() error
 	// ScaleDown scales down the workload
-	ScaleDown(downscaleReplicas values.Replicas) error
+	ScaleDown(downscaleReplicas values.Replicas) (float64, float64, error)
 }
 
 type Clientsets struct {

--- a/internal/pkg/util/config.go
+++ b/internal/pkg/util/config.go
@@ -35,6 +35,8 @@ type RuntimeConfiguration struct {
 	MaxRetriesOnConflict int
 	// Kubeconfig sets an optional kubeconfig to use for testing purposes instead of the in-cluster config.
 	Kubeconfig string
+	// MetricsEnabled sets if Prometheus metrics should be exposed.
+	MetricsEnabled bool
 }
 
 func GetDefaultConfig() *RuntimeConfiguration {
@@ -50,6 +52,7 @@ func GetDefaultConfig() *RuntimeConfiguration {
 		IncludeLabels:     nil,
 		TimeAnnotation:    "",
 		Kubeconfig:        "",
+		MetricsEnabled:    false,
 	}
 }
 
@@ -126,6 +129,12 @@ func (c *RuntimeConfiguration) ParseConfigFlags() {
 		"max-retries-on-conflict",
 		0,
 		"the annotation to use instead of creation time for grace period (optional)",
+	)
+	flag.BoolVar(
+		&c.MetricsEnabled,
+		"metrics",
+		false,
+		"expose Prometheus metrics (default: false)",
 	)
 }
 

--- a/internal/pkg/values/scope.go
+++ b/internal/pkg/values/scope.go
@@ -63,6 +63,7 @@ type Scope struct {
 	DownscaleReplicas Replicas      // the replicas to scale down to
 	GracePeriod       time.Duration // grace period until new workloads will be scaled down
 	ScaleChildren     triStateBool  // ownerReference will immediately trigger scaling of children workloads, when applicable
+	MetricsEnabled    bool          // whether Prometheus metrics are enabled
 }
 
 func GetDefaultScope() *Scope {
@@ -78,6 +79,7 @@ func GetDefaultScope() *Scope {
 		DownscaleReplicas: AbsoluteReplicas(0),
 		GracePeriod:       15 * time.Minute,
 		ScaleChildren:     triStateBool{isSet: false, value: false},
+		MetricsEnabled:    false,
 	}
 }
 

--- a/internal/pkg/values/scope.go
+++ b/internal/pkg/values/scope.go
@@ -63,7 +63,6 @@ type Scope struct {
 	DownscaleReplicas Replicas      // the replicas to scale down to
 	GracePeriod       time.Duration // grace period until new workloads will be scaled down
 	ScaleChildren     triStateBool  // ownerReference will immediately trigger scaling of children workloads, when applicable
-	MetricsEnabled    bool          // whether Prometheus metrics are enabled
 }
 
 func GetDefaultScope() *Scope {
@@ -79,7 +78,6 @@ func GetDefaultScope() *Scope {
 		DownscaleReplicas: AbsoluteReplicas(0),
 		GracePeriod:       15 * time.Minute,
 		ScaleChildren:     triStateBool{isSet: false, value: false},
-		MetricsEnabled:    false,
 	}
 }
 

--- a/internal/pkg/values/scopeParser.go
+++ b/internal/pkg/values/scopeParser.go
@@ -86,6 +86,12 @@ func (s *Scope) ParseScopeFlags() {
 		"scale-children",
 		"if set to true, the ownerReference will immediately trigger scaling of children workloads when applicable (default: false)",
 	)
+	flag.BoolVar(
+		&s.MetricsEnabled,
+		"metrics",
+		false,
+		"if set to true, the downscaler will serve Prometheus metrics on port 8085 (default: false)",
+	)
 }
 
 // GetScopeFromEnv fills l with all values from environment variables and checks for compatibility.

--- a/internal/pkg/values/scopeParser.go
+++ b/internal/pkg/values/scopeParser.go
@@ -86,12 +86,6 @@ func (s *Scope) ParseScopeFlags() {
 		"scale-children",
 		"if set to true, the ownerReference will immediately trigger scaling of children workloads when applicable (default: false)",
 	)
-	flag.BoolVar(
-		&s.MetricsEnabled,
-		"metrics",
-		false,
-		"if set to true, the downscaler will serve Prometheus metrics on port 8085 (default: false)",
-	)
 }
 
 // GetScopeFromEnv fills l with all values from environment variables and checks for compatibility.

--- a/website/content/docs/1 - downscaler/4 - Metrics.mdx
+++ b/website/content/docs/1 - downscaler/4 - Metrics.mdx
@@ -1,0 +1,126 @@
+---
+title: Metrics
+id: metrics
+globalReference: docs-metrics
+description: Explain all the metrics exposed by the GoKubeDownscaler and how they can be used to monitor the Downscaler's activity.
+keywords: [metrics]
+---
+
+# Metrics
+
+GoKubeDownscaler exposes a set of Prometheus metrics that can be used to monitor its activity and performance.
+These metrics provide insights into the
+targets, scaling operations, performance and general statistics and can be used to set up alerts or dashboards.
+
+The metrics are available at the `/metrics` endpoint of the GoKubeDownscaler, which is exposed on port `8085`.
+
+Metrics are divided into three main categories:
+
+- **Dry-Run Metrics**: A set of metrics that are exposed only when the GoKubeDownscaler is run in dry-run mode.
+  They are useful to monitor the potential
+  impact of configurations and the potential economic savings in terms of saved CPU and memory.
+  They provide a great aid in the adoption phase of the GoKubeDownscaler.
+- **Production Metrics**: A set of metrics that are exposed when the GoKubeDownscaler is run in the standard mode.
+  They provide insights into the actual
+  scaling operations, performance and real economic savings of the Downscaler.
+- **Common Metrics**: A set of metrics that are always exposed, regardless of the mode the GoKubeDownscaler is running in.
+  These metrics provide general
+  statistics and performance information.
+
+:::tip
+
+We recommend to set up alerts only for production metrics, as the dry-run metrics are not meant to be used
+in a production environment.
+
+:::
+
+## List of Metrics
+
+Here is a list of all the metrics currently exposed by the GoKubeDownscaler, divided into dry-run and production metrics.
+
+### Dry-Run Metrics
+
+- **metric_name**: `kubedownscaler_potential_downscaled_workloads`
+  - type: gauge
+  - dimensions: namespace
+  - description: Number of potential downscaled workloads managed by KubeDownscaler broken down by namespace.
+
+- **metric_name**: `kubedownscaler_potential_upscaled_workloads`
+  - type: gauge
+  - dimensions: namespace
+  - description: Number of potential upscaled workloads managed by KubeDownscaler broken down by namespace.
+
+- **metric_name**: `kubedownscaler_potential_excluded_workloads`
+  - type: gauge
+  - dimensions: namespace
+  - description: Number of potential workloads excluded from kubedownscaler management broken down by namespace.
+
+- **metric_name**: `kubedownscaler_potential_current_saved_memory_bytes`
+  - type: gauge
+  - dimensions: namespace
+  - description: Number of potential bytes of memory saved by KubeDownscaler downscaling actions.
+    Workloads managed by
+    Keda ScaledObjects are not included in this metric.
+
+- **metric_name**: `kubedownscaler_potential_current_saved_cpu_cores`
+  - type: gauge
+  - dimensions: namespace
+  - description: Number of potential cores of cpu saved by KubeDownscaler downscaling actions.
+    Workloads managed by
+    Keda ScaledObjects are not included in this metric.
+
+### Production Metrics
+
+- **metric_name**: `kubedownscaler_downscaled_workloads`
+  - type: gauge
+  - dimensions: namespace
+  - description: Number of downscaled workloads managed by KubeDownscaler broken down by namespace.
+
+- **metric_name**: `kubedownscaler_upscaled_workloads`
+  - type: gauge
+  - dimensions: namespace
+  - description: Number of upscaled workloads managed by KubeDownscaler broken down by namespace.
+
+- **metric_name**: `kubedownscaler_excluded_workloads`
+  - type: gauge
+  - dimensions: namespace
+  - description: Number of workloads excluded from KubeDownscaler management broken down by namespace.
+
+- **metric_name**: `kubedownscaler_current_saved_memory_bytes`
+  - type: gauge
+  - dimensions: namespace
+  - description: Number of bytes of memory saved by KubeDownscaler downscaling actions.
+    Workloads managed by
+    Keda ScaledObjects are not included in this metric.
+
+- **metric_name**: `kubedownscaler_current_saved_cpu_cores`
+  - type: gauge
+  - dimensions: namespace
+  - description: Number of cores of cpu saved by KubeDownscaler downscaling actions.
+    Workloads managed by
+    Keda ScaledObjects are not included in this metric.
+
+### Common Metrics
+
+- **metric_name**: `kubedownscaler_scaling_errors`
+  - type: gauge
+  - dimensions: namespace, type
+  - description: Number of scaling errors encountered during the scale process.
+
+- **metric_name**: `kubedownscaler_cycle_duration_seconds`
+  - type: gauge
+  - description: Duration of kubedownscaler cycle in seconds.
+
+- **metric_name**: `kubedownscaler_cycle_executions_total`
+  - type: counter
+  - description: Number of cycles completed by KubeDownscaler since being instantiated.
+
+:::tip
+
+When `kubedownscaler_cycle_duration_seconds` has a high value, it could be useful to review the resource requests and limits of
+the downscaler to ensure it has enough resources to operate efficiently.
+Another option is to [enable concurrency](ref:guides-concurrency)
+If these options aren’t viable, we recommend setting the [`--max-retries-on-conflict flag`](ref:docs-runtime-configuration#max-retries-on-conflict)
+This helps handle cases where the resource is modified by another component between the time it's fetched and updated by the downscaler.
+
+:::

--- a/website/content/docs/1 - downscaler/index.mdx
+++ b/website/content/docs/1 - downscaler/index.mdx
@@ -18,6 +18,7 @@ The following pages will go in depth on the following topics:
   and explain how they are scaled
 - [Configurations](ref:docs-configurations): List all the configurations available at any scope for the Downscaler
 - [Types](ref:docs-types): List and explain the custom types used by the Downscaler (e.g. Timespans, Durations, etc.)
+- [Metrics](ref:docs-metrics): Explain all the metrics exposed by the Downscaler and how they can be used to monitor the Downscaler's activity
 
 Once you are familiar with the basic concepts of the Downscaler, you can move on to the
 [Helm Chart documentation section](ref:docs-helm) to learn how you can apply the concepts you learned to create a basic

--- a/website/content/docs/2 - helm-chart/0 - Components.mdx
+++ b/website/content/docs/2 - helm-chart/0 - Components.mdx
@@ -15,6 +15,12 @@ The following Kubernetes Objects can be created with our Helm Chart:
 The [deployment.yaml](repo:deployments/chart/templates/deployment.yaml) file creates the main Deployment of the GoKubeDownscaler
 with a reference to the provided ServiceAccount and ConfigMap.
 
+## Service
+
+The [service.yaml](repo:deployments/chart/templates/service.yaml) file creates the main Service of the GoKubeDownscaler.
+This
+Service is created only when [`--metrics`](ref:docs-metrics) are enabled.
+
 ## Serviceaccount
 
 The [serviceaccount.yaml](repo:deployments/chart/templates/serviceaccount.yaml) file creates a ServiceAccount

--- a/website/content/docs/2 - helm-chart/2 - values/19 - metrics.mdx
+++ b/website/content/docs/2 - helm-chart/2 - values/19 - metrics.mdx
@@ -1,0 +1,33 @@
+---
+title: metrics
+id: metrics
+globalReference: docs-helm-metrics
+description: How to enable Prometheus metrics for the GoKubeDownscaler in the Helm Chart
+keywords: [metrics]
+---
+
+# serviceAccount
+
+The `metrics` value contains one field:
+
+- `enabled` is a boolean value indicating if metrics should be enabled or not
+
+:::info
+
+The default values for `metrics` are:
+
+```yaml
+metrics:
+  enabled: true
+```
+
+:::
+
+By default the `metrics.enabled` value of the Helm Chart is set to false.
+When set to true, the Helm Chart will create
+a Service that exposes the GoKubeDownscaler metrics on port 8085.
+To understand which metrics are exposed and how to use
+them refer to the [metrics documentation](ref:docs-metrics).
+Enabling metrics can impact the performance of the GoKubeDownscaler,
+especially memory usage, so it is recommended to monitor the resource usage of the GoKubeDownscaler when enabling metrics,
+especially in very large clusters.


### PR DESCRIPTION
## Motivation

As described in #174 the Downscaler currently doesn't expose metric. Adding metrics could be useful to monitor the tool through custom dashboards and alerts

## Changes

Code:

- added `metrics` package and all related class as sub-package of `pkg`
- added instrumentation code (includes managing stale metrics)
- refactored functions in `cmd` and `pkg` to accomodate instrumentation code

Helm:

- added `metrics` argument
- when the metrics argument is set to true, a new `Service` gets created to expose the main `Deployment` on port `8085`

Docs:

- added docs for `metrics`
- added helm docs related to the `metrics` argument
- refactored component helm docs to explain the goal of the Service and when it gets created

## Tests Done

- Unit Tests

## TODO

- [ ] Check Performance
