### PR TITLE
Refactor/installation docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 fail_fast: true
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
         exclude: '\.(json)$'
@@ -9,7 +9,7 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, main]
   - repo: https://github.com/tekwizely/pre-commit-golang
-    rev: v1.0.0-rc.1
+    rev: v1.0.0-rc.2
     hooks:
       - id: go-mod-tidy-repo
       - id: go-test-repo-mod

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, main]
   - repo: https://github.com/tekwizely/pre-commit-golang
-    rev: v1.0.0-rc.1
+    rev: v1.0.0-rc.2
     hooks:
       - id: go-mod-tidy-repo
       - id: go-test-repo-mod

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, main]
   - repo: https://github.com/tekwizely/pre-commit-golang
-    rev: v1.0.0-rc.2
+    rev: v1.0.0-rc.1
     hooks:
       - id: go-mod-tidy-repo
       - id: go-test-repo-mod

--- a/website/content/guides/0 - getting-started/0 - Installation.mdx
+++ b/website/content/guides/0 - getting-started/0 - Installation.mdx
@@ -19,6 +19,24 @@ In order to get started installing the GoKubeDownscaler using our Helm Chart you
 
 Also make sure your context is set to the right cluster and namespace where you want to deploy the GoKubeDownscaler.
 
+## Constrained Installation vs Cluster-Wide Installation
+
+As described in the [Architecture](ref:docs-architecture) section, the GoKubeDownscaler can be installed in two different ways:
+
+- **Constrained Installation**: The GoKubeDownscaler is only allowed to operate on a set of namespaces.
+  This is useful if you don't have the
+  necessary rights to make a cluster-wide installation.
+- **Cluster-Wide Installation**: The GoKubeDownscaler is allowed to operate
+
+In order to install the GoKubeDownscaler in a constrained way you must set the `constrainedNamespaces` value.
+This can be done in two ways:
+
+- by passing the `--set constrainedNamespaces=[namespace1,namespace2,...]` argument to the `helm install` or `helm template` command shown
+  in the next section
+- by setting it in the `values.yaml` file.
+
+[This documentation page](ref:docs-helm-constrained-namespaces) explains how to use this argument and what it does under the hood
+
 ## Install the Chart with Helm
 
 In order to install the chart on your cluster you only need to run one simple command:

--- a/website/content/guides/0 - getting-started/0 - Installation.mdx
+++ b/website/content/guides/0 - getting-started/0 - Installation.mdx
@@ -21,12 +21,13 @@ Also make sure your context is set to the right cluster and namespace where you 
 
 ## Constrained Installation vs Cluster-Wide Installation
 
-As described in the [introduction page](ref:docs-introduction#installation-and-architecture), the GoKubeDownscaler can be installed in two different ways:
+As described in the [introduction page](ref:docs-introduction#installation-and-architecture), the GoKubeDownscaler can be installed in two
+different ways:
 
 - **Constrained Installation**: The GoKubeDownscaler is only allowed to operate on a set of namespaces.
-  This is useful if you don't have the
-  necessary rights to make a cluster-wide installation.
-- **Cluster-Wide Installation**: The GoKubeDownscaler is allowed to operate
+  This is useful if you don't have the necessary rights to make a cluster-wide installation.
+- **Cluster-Wide Installation**: The GoKubeDownscaler is allowed to operate on all namespaces in the cluster.
+  This is useful if you want to scale down workloads across the entire cluster.
 
 In order to install the GoKubeDownscaler in a constrained way you must set the `constrainedNamespaces` value.
 This can be done in two ways:

--- a/website/content/guides/0 - getting-started/0 - Installation.mdx
+++ b/website/content/guides/0 - getting-started/0 - Installation.mdx
@@ -21,7 +21,7 @@ Also make sure your context is set to the right cluster and namespace where you 
 
 ## Constrained Installation vs Cluster-Wide Installation
 
-As described in the [Architecture](ref:docs-architecture) section, the GoKubeDownscaler can be installed in two different ways:
+As described in the [introduction page](ref:docs-introduction#installation-and-architecture), the GoKubeDownscaler can be installed in two different ways:
 
 - **Constrained Installation**: The GoKubeDownscaler is only allowed to operate on a set of namespaces.
   This is useful if you don't have the


### PR DESCRIPTION
## Motivation

Right now the installation guide it's not very explicit on Cluster-Wide mode vs Constrained mode. Users can find out about these options reading carefully the `values.yaml` as pointed out in the last subsection of the page but sometimes this could be overlooked if the information is not immediately made available to the user ([py-kube-downscaler installation docs](https://github.com/caas-team/py-kube-downscaler?tab=readme-ov-file#installation)). Since these modes are important to know before starting the installation process, I think it would better to explicitly create a dedicated subsection explaining them (and how to set them in the installation process) just before the installation sub section

## Changes

- added a subsection inside the installation guide page of the documentation that allows users to better understand how to activate the constrainedNamespace option

## Tests Done

- Not needed
