### PR TITLE
Chore/Bumping Go Version For Project And Base Images

### DIFF
--- a/build/admissioncontroller/Dockerfile
+++ b/build/admissioncontroller/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4 AS build
+FROM golang:1.25.6 AS build
 
 WORKDIR /tmp/kubedownscaler
 

--- a/build/kubedownscaler/Dockerfile
+++ b/build/kubedownscaler/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.3 AS build
+FROM golang:1.25.6 AS build
 
 WORKDIR /tmp/kubedownscaler
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/caas-team/gokubedownscaler
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/argoproj/argo-rollouts v1.8.3


### PR DESCRIPTION
## Motivation

To prepare for the next release, we need to bump Go version for the whole project and its base images

## Changes

- Bumped Go version in go.mod
- Bumped Go version in base images

## Tests Done

- Unit Tests
- Live Tests
