### PR TITLE
Chore/Added Build For AdmissionController Image In Github Actions

### DIFF
--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -103,3 +103,11 @@ jobs:
           gh_user: caas-team
           package_name: gokubedownscaler
           tag: ${{ inputs.appVersion }}
+
+      - name: Tag untagged versions webhook
+        uses: jtaeuber/tag-multiarch-images@v0.1.0
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          gh_user: caas-team
+          package_name: gokubedownscaler-webhook
+          tag: ${{ inputs.appVersion }}


### PR DESCRIPTION
## Motivation

After merging the AdmissionController Webhook PR (#131), we need to refactor the related Github Action build and push stage

## Changes

- Added dedicated task to gather metadata to be used in the build for AdmissionController Webhook image
- Added dedicated task to build AdmissionController Webhook image
- Added in the already existing task, the cosign signature for AdmissionController Webhook image

## Tests Done

- Waiting for Jonathan and Jan to test the workflow

## TODO

- [x] To Be Tested