### PR TITLE
fix(helm): correct MutatingAdmissionPolicy matchConditions CEL expressions

### DIFF
--- a/deployments/chart/templates/mutatingadmissionpolicy.yaml
+++ b/deployments/chart/templates/mutatingadmissionpolicy.yaml
@@ -25,29 +25,29 @@ spec:
     {{- end }}
   matchConditions:
     - name: kube-downscaler-webhook-sa
-      expression: 'has(object.metadata.annotations) && object.metadata.annotations.exists(l, l.startsWith("downscaler/") && (oldObject != null || !has(oldObject.metadata.annotations) || !(l in oldObject.metadata.annotations) || object.metadata.annotations[l] != oldObject.metadata.annotations[l])) && request.userInfo.username != "system:serviceaccount:{{ .Release.Namespace }}:{{ include "go-kube-downscaler.webhookController.fullname" . }}"'
+      expression: 'has(object.metadata.annotations) && object.metadata.annotations.exists(l, l.startsWith("downscaler/") && (oldObject == null || !has(oldObject.metadata.annotations) || !(l in oldObject.metadata.annotations) || object.metadata.annotations[l] != oldObject.metadata.annotations[l])) && request.userInfo.username != "system:serviceaccount:{{ .Release.Namespace }}:{{ include "go-kube-downscaler.webhookController.fullname" . }}"'
     - name: kube-downscaler-sa
-      expression: 'has(object.metadata.annotations) && object.metadata.annotations.exists(l, l.startsWith("downscaler/") && (oldObject != null || !has(oldObject.metadata.annotations) || !(l in oldObject.metadata.annotations) || object.metadata.annotations[l] != oldObject.metadata.annotations[l])) && request.userInfo.username != "system:serviceaccount:{{ .Release.Namespace }}:{{ include "go-kube-downscaler.serviceAccountName" . }}"'
+      expression: 'has(object.metadata.annotations) && object.metadata.annotations.exists(l, l.startsWith("downscaler/") && (oldObject == null || !has(oldObject.metadata.annotations) || !(l in oldObject.metadata.annotations) || object.metadata.annotations[l] != oldObject.metadata.annotations[l])) && request.userInfo.username != "system:serviceaccount:{{ .Release.Namespace }}:{{ include "go-kube-downscaler.serviceAccountName" . }}"'
     {{- if .Values.annotationsCompliance.authorizedNamespacesToServiceAccountsRegex }}
     {{- $nameIndex := 0 }}
     {{- range $namespaceRegex, $serviceAccounts := .Values.annotationsCompliance.authorizedNamespacesToServiceAccountsRegex }}
     {{- range $index, $saRegex := $serviceAccounts }}
     {{- $nameIndex = add $nameIndex 1 }}
     - name: authorized-sa-pattern-{{index}}-{{$nameIndex}}
-      expression: 'has(object.metadata.annotations) && object.metadata.annotations.exists(l, l.startsWith("downscaler/") && (oldObject != null || !has(oldObject.metadata.annotations) || !(l in oldObject.metadata.annotations) || object.metadata.annotations[l] != oldObject.metadata.annotations[l])) && !request.userInfo.username.matches("^system:serviceaccount:{{$namespaceRegex}}:{{$saRegex}}")'
+      expression: 'has(object.metadata.annotations) && object.metadata.annotations.exists(l, l.startsWith("downscaler/") && (oldObject == null || !has(oldObject.metadata.annotations) || !(l in oldObject.metadata.annotations) || object.metadata.annotations[l] != oldObject.metadata.annotations[l])) && !request.userInfo.username.matches("^system:serviceaccount:{{$namespaceRegex}}:{{$saRegex}}")'
     {{- end }}
     {{- end }}
     {{- end }}
     {{- if .Values.annotationsCompliance.authorizedUsersRegex }}
     {{- range $index, $userRegex := .Values.annotationsCompliance.authorizedUsersRegex }}
     - name: authorized-user-pattern-{{$index}}
-      expression: 'has(object.metadata.annotations) && object.metadata.annotations.exists(l, l.startsWith("downscaler/") && (oldObject != null || !has(oldObject.metadata.annotations) || !(l in oldObject.metadata.annotations) || object.metadata.annotations[l] != oldObject.metadata.annotations[l])) && !request.userInfo.username.matches("{{ $userRegex }}")'
+      expression: 'has(object.metadata.annotations) && object.metadata.annotations.exists(l, l.startsWith("downscaler/") && (oldObject == null || !has(oldObject.metadata.annotations) || !(l in oldObject.metadata.annotations) || object.metadata.annotations[l] != oldObject.metadata.annotations[l])) && !request.userInfo.username.matches("{{ $userRegex }}")'
     {{- end }}
     {{- end }}
     {{- if .Values.annotationsCompliance.authorizedGroupsRegex }}
     {{- range $index, $groupRegex := .Values.annotationsCompliance.authorizedGroupsRegex }}
     - name: authorized-group-pattern-{{$index}}
-      expression: 'has(object.metadata.annotations) && object.metadata.annotations.exists(l, l.startsWith("downscaler/") && (oldObject != null || !has(oldObject.metadata.annotations) || !(l in oldObject.metadata.annotations) || object.metadata.annotations[l] != oldObject.metadata.annotations[l])) && !request.userInfo.groups.exists(g, g.matches("{{ $groupRegex }}"))'
+      expression: 'has(object.metadata.annotations) && object.metadata.annotations.exists(l, l.startsWith("downscaler/") && (oldObject == null || !has(oldObject.metadata.annotations) || !(l in oldObject.metadata.annotations) || object.metadata.annotations[l] != oldObject.metadata.annotations[l])) && !request.userInfo.groups.exists(g, g.matches("{{ $groupRegex }}"))'
     {{- end }}
     {{- end }}
   failurePolicy: Ignore


### PR DESCRIPTION
## Summary

All `matchConditions` CEL expressions in `mutatingadmissionpolicy.yaml` used `oldObject != null` where `oldObject == null` was intended.

The condition is part of an OR clause that determines whether a `downscaler/` annotation is being **added for the first time**:

```
oldObject == null                                              → CREATE (no prior object)
|| !has(oldObject.metadata.annotations)                       → prior object had no annotations
|| !(l in oldObject.metadata.annotations)                     → annotation is new
|| object.metadata.annotations[l] != oldObject.metadata.annotations[l]  → value changed
```

With `!= null`, the first clause evaluated to `true` only when `oldObject` was present (UPDATE operations), making the OR effectively always true on UPDATE — but this branch was supposed to catch CREATE operations (new objects with no prior state). Correcting to `== null` restores the intended semantics.

## Impact

Without this fix, the `MutatingAdmissionPolicy` (Kubernetes ≥ 1.34) would not correctly block unauthorized `downscaler/` annotation additions on freshly created resources (CREATE requests). UPDATE protection was unaffected.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: template-only fix with no runtime behavior changes outside `MutatingAdmissionPolicy` enforcement (opt-in feature, requires K8s ≥ 1.34 and `annotationsCompliance.mutateUnauthorizedAnnotationsAddition: true`).

---

🤖 Generated with Claude Sonnet 4.6 (200K context) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.40.0