### PR TITLE
fix(chart): omit EXCLUDE_NAMESPACES when excludedNamespaces is empty

### DIFF
--- a/deployments/chart/templates/configmap.yaml
+++ b/deployments/chart/templates/configmap.yaml
@@ -4,7 +4,9 @@ metadata:
   name: {{ .Values.configMap.name }}
   namespace: {{ .Release.Namespace }}
 data:
-  EXCLUDE_NAMESPACES: '{{- join "," .Values.excludedNamespaces }}'
+  {{- with .Values.excludedNamespaces }}
+  EXCLUDE_NAMESPACES: '{{ join "," . }}'
+  {{- end }}
   {{- if .Values.configMap.extraConfig }}
   {{- tpl .Values.configMap.extraConfig . | nindent 2 }}
   {{- end }}

--- a/deployments/chart/templates/configmap.yaml
+++ b/deployments/chart/templates/configmap.yaml
@@ -4,9 +4,7 @@ metadata:
   name: {{ .Values.configMap.name }}
   namespace: {{ .Release.Namespace }}
 data:
-  {{- with .Values.excludedNamespaces }}
-  EXCLUDE_NAMESPACES: '{{ join "," . }}'
-  {{- end }}
+  EXCLUDE_NAMESPACES: '{{ join "," (coalesce .Values.excludedNamespaces (list .Release.Namespace "kube-system")) }}'
   {{- if .Values.configMap.extraConfig }}
   {{- tpl .Values.configMap.extraConfig . | nindent 2 }}
   {{- end }}

--- a/website/content/docs/3 - helm-chart/2 - values/16 - excludedNamespaces.mdx
+++ b/website/content/docs/3 - helm-chart/2 - values/16 - excludedNamespaces.mdx
@@ -41,7 +41,8 @@ Will result in all workloads in the namespaces `kube-downscaler`, `kube-system` 
 
 :::note
 
-Setting `excludedNamespaces: []` does not clear the exclusion list. The chart omits the `EXCLUDE_NAMESPACES` env var when the list is empty, so the binary falls back to its built-in default (`kube-system`, `kube-downscaler`). To truly exclude nothing, set a regex that cannot match any namespace name, such as `["$^"]`.
+Setting `excludedNamespaces: []` does not clear the exclusion list.
+The chart omits the `EXCLUDE_NAMESPACES` env var when the list is empty, so the binary falls back to its built-in default (`kube-system`, `kube-downscaler`). To truly exclude nothing, set a regex that cannot match any namespace name, such as `["$^"]`.
 
 :::
 

--- a/website/content/docs/3 - helm-chart/2 - values/16 - excludedNamespaces.mdx
+++ b/website/content/docs/3 - helm-chart/2 - values/16 - excludedNamespaces.mdx
@@ -12,7 +12,8 @@ The `excludedNamespaces` value is a list of namespaces that will be excluded fro
 
 :::info
 
-When `excludedNamespaces` is empty, the chart defaults to excluding `kube-system` and the release namespace (the namespace where the chart is installed). When running the binary standalone (outside the chart), the built-in defaults are `kube-system` and `kube-downscaler`.
+When `excludedNamespaces` is empty, the chart defaults to excluding `kube-system` and the release namespace (the namespace where the chart is installed).
+When running the binary standalone (outside the chart), the built-in defaults are `kube-system` and `kube-downscaler`.
 
 Explicit default in `values.yaml`:
 
@@ -43,7 +44,8 @@ Will result in all workloads in the namespaces `kube-downscaler`, `kube-system` 
 
 :::note
 
-Setting `excludedNamespaces: []` does not clear the exclusion list. The chart substitutes `kube-system` and the release namespace as defaults via `coalesce`. To truly exclude nothing, set a regex that cannot match any namespace name, such as `["$^"]`.
+Setting `excludedNamespaces: []` does not clear the exclusion list.
+The chart substitutes `kube-system` and the release namespace as defaults via `coalesce`. To truly exclude nothing, set a regex that cannot match any namespace name, such as `["$^"]`.
 
 :::
 

--- a/website/content/docs/3 - helm-chart/2 - values/16 - excludedNamespaces.mdx
+++ b/website/content/docs/3 - helm-chart/2 - values/16 - excludedNamespaces.mdx
@@ -12,7 +12,9 @@ The `excludedNamespaces` value is a list of namespaces that will be excluded fro
 
 :::info
 
-The default value for `excludedNamespaces` is:
+When `excludedNamespaces` is empty, the chart defaults to excluding `kube-system` and the release namespace (the namespace where the chart is installed). When running the binary standalone (outside the chart), the built-in defaults are `kube-system` and `kube-downscaler`.
+
+Explicit default in `values.yaml`:
 
 ```yaml
 excludedNamespaces:
@@ -41,8 +43,7 @@ Will result in all workloads in the namespaces `kube-downscaler`, `kube-system` 
 
 :::note
 
-Setting `excludedNamespaces: []` does not clear the exclusion list.
-The chart omits the `EXCLUDE_NAMESPACES` env var when the list is empty, so the binary falls back to its built-in default (`kube-system`, `kube-downscaler`). To truly exclude nothing, set a regex that cannot match any namespace name, such as `["$^"]`.
+Setting `excludedNamespaces: []` does not clear the exclusion list. The chart substitutes `kube-system` and the release namespace as defaults via `coalesce`. To truly exclude nothing, set a regex that cannot match any namespace name, such as `["$^"]`.
 
 :::
 

--- a/website/content/docs/3 - helm-chart/2 - values/16 - excludedNamespaces.mdx
+++ b/website/content/docs/3 - helm-chart/2 - values/16 - excludedNamespaces.mdx
@@ -39,4 +39,10 @@ Will result in all workloads in the namespaces `kube-downscaler`, `kube-system` 
 
 :::
 
+:::note
+
+Setting `excludedNamespaces: []` does not clear the exclusion list. The chart omits the `EXCLUDE_NAMESPACES` env var when the list is empty, so the binary falls back to its built-in default (`kube-system`, `kube-downscaler`). To truly exclude nothing, set a regex that cannot match any namespace name, such as `["$^"]`.
+
+:::
+
 For more information please see [the documentation on the configuration](ref:docs-runtime-configuration#exclude-namespaces).

--- a/website/content/docs/3 - helm-chart/2 - values/16 - excludedNamespaces.mdx
+++ b/website/content/docs/3 - helm-chart/2 - values/16 - excludedNamespaces.mdx
@@ -12,7 +12,8 @@ The `excludedNamespaces` value is a list of namespaces that will be excluded fro
 
 :::info
 
-When `excludedNamespaces` is empty, the chart defaults to excluding `kube-system` and the release namespace (the namespace where the chart is installed).
+When `excludedNamespaces` is empty, the chart defaults to excluding `kube-system` and the release namespace
+(the namespace where the chart is installed).
 When running the binary standalone (outside the chart), the built-in defaults are `kube-system` and `kube-downscaler`.
 
 Explicit default in `values.yaml`:

--- a/website/content/docs/3 - helm-chart/2 - values/16 - excludedNamespaces.mdx
+++ b/website/content/docs/3 - helm-chart/2 - values/16 - excludedNamespaces.mdx
@@ -45,7 +45,8 @@ Will result in all workloads in the namespaces `kube-downscaler`, `kube-system` 
 :::note
 
 Setting `excludedNamespaces: []` does not clear the exclusion list.
-The chart substitutes `kube-system` and the release namespace as defaults via `coalesce`. To truly exclude nothing, set a regex that cannot match any namespace name, such as `["$^"]`.
+The chart substitutes `kube-system` and the release namespace as defaults via `coalesce`.
+To truly exclude nothing, set a regex that cannot match any namespace name, such as `["$^"]`.
 
 :::
 


### PR DESCRIPTION
## Summary

Fixes part B of #451. Setting `excludedNamespaces: []` in `values.yaml` currently renders `EXCLUDE_NAMESPACES: ''` in the ConfigMap. Because the env var is *set* (with an empty value), the binary calls `RegexList.Set(\"\")`, which produces a regex `\"\"` that matches every string — silently excluding all namespaces and disabling the downscaler.

This PR guards the ConfigMap key with `{{- with .Values.excludedNamespaces }}` so an empty list falls back to the Go default (`kube-system`, `kube-downscaler`) instead of being rendered as an empty env var.

## Changes

- `deployments/chart/templates/configmap.yaml` — only emit `EXCLUDE_NAMESPACES` when the list is non-empty.
- `website/content/docs/3 - helm-chart/2 - values/16 - excludedNamespaces.mdx` — document the behavior and how to truly exclude nothing (`[\"$^\"]`).

## Verification

\`\`\`console
$ helm lint deployments/chart/
1 chart(s) linted, 0 chart(s) failed

$ helm template test deployments/chart/ | grep EXCLUDE_NAMESPACES
  EXCLUDE_NAMESPACES: 'kube-downscaler,kube-system'

$ helm template test deployments/chart/ --set-json 'excludedNamespaces=[]' | grep EXCLUDE_NAMESPACES
# (no output — key is omitted, Go defaults apply)
\`\`\`

## Scope

This is the chart-side fix (B) from #451. The companion design fix (A) — making `--namespace` take precedence over `--exclude-namespaces` so `constrainedNamespaces` works without touching `excludedNamespaces` — is intentionally left to a separate discussion in that issue.

Refs #451