### PR TITLE
Feat/Add minimum-replicas value to skip downscaling small workloads

### DIFF
--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -414,6 +414,8 @@ func scaleWorkloads(
 }
 
 // scaleWorkload scales the given workload according to the given wanted scaling state.
+//
+//nolint:cyclop // one branch per Scaling state, splitting it up doesn't really help
 func scaleWorkload(
 	scaling values.Scaling,
 	workload scalable.Workload,
@@ -461,9 +463,18 @@ setting different scaling states at the same time (e.g. downtime-period and upti
 			return fmt.Errorf("failed to get downscale replicas: %w", err)
 		}
 
-		savedResources, err := client.DownscaleWorkload(downscaleReplicas, workload, ctx)
+		minimumReplicas := scopes.GetMinimumReplicas()
+
+		savedResources, err := client.DownscaleWorkload(downscaleReplicas, minimumReplicas, workload, ctx)
 		if err != nil {
 			return fmt.Errorf("failed to downscale workload: %w", err)
+		}
+
+		if savedResources == nil {
+			slog.Debug("workload is below minimum replicas, skipping", "workload", workload.GetName(), "namespace", workload.GetNamespace())
+			workloadNamespaceMetrics.IncrementExcludedWorkloadsCount()
+
+			return nil
 		}
 
 		workloadNamespaceMetrics.IncrementDownscaledWorkloadsCount()

--- a/cmd/kubedownscaler/main_test.go
+++ b/cmd/kubedownscaler/main_test.go
@@ -26,12 +26,17 @@ func (m *MockClient) GetNamespaceAnnotations(namespace string, ctx context.Conte
 }
 
 func (m *MockClient) DownscaleWorkload(
-	replicas values.Replicas,
+	replicas, minimumReplicas values.Replicas,
 	workload scalable.Workload,
 	ctx context.Context,
 ) (*metrics.SavedResources, error) {
-	args := m.Called(replicas, workload, ctx)
-	return args.Get(0).(*metrics.SavedResources), args.Error(1)
+	args := m.Called(replicas, minimumReplicas, workload, ctx)
+
+	if got := args.Get(0); got != nil {
+		return got.(*metrics.SavedResources), args.Error(1)
+	}
+
+	return nil, args.Error(1)
 }
 
 func (m *MockClient) UpscaleWorkload(workload scalable.Workload, ctx context.Context) error {
@@ -96,7 +101,51 @@ func TestScanWorkload(t *testing.T) {
 	mockWorkload.On("GetAnnotations").Return(map[string]string{
 		"downscaler/force-downtime": "true",
 	})
-	mockClient.On("DownscaleWorkload", values.AbsoluteReplicas(0), mockWorkload, ctx).Return(metrics.NewSavedResources(0, 0), nil)
+	mockClient.On("DownscaleWorkload", values.AbsoluteReplicas(0), values.Replicas(nil), mockWorkload, ctx).
+		Return(metrics.NewSavedResources(0, 0), nil)
+	err := scanWorkload(mockWorkload, mockClient, ctx, values.GetDefaultScope(), scopeCli, scopeEnv, namespaceScopes, namespaceMetrics, config)
+
+	require.NoError(t, err)
+
+	mockClient.AssertExpectations(t)
+	mockWorkload.AssertExpectations(t)
+}
+
+func TestScanWorkloadBelowMinimumReplicas(t *testing.T) {
+	t.Parallel()
+
+	slog.SetLogLoggerLevel(slog.LevelDebug)
+
+	ctx := t.Context()
+
+	scopeCli := values.NewScope()
+	scopeEnv := values.NewScope()
+	config := &runtimeConfiguration{}
+
+	scopeCli.DownscaleReplicas = values.AbsoluteReplicas(1)
+	scopeCli.MinimumReplicas = values.AbsoluteReplicas(2)
+	scopeCli.GracePeriod = 15 * time.Minute
+
+	namespaceScopes := map[string]*values.Scope{
+		"test-namespace": {
+			GracePeriod: 15 * time.Minute,
+		},
+	}
+
+	namespaceMetrics := &metrics.NamespaceMetricsHolder{}
+
+	mockClient := new(MockClient)
+	mockWorkload := new(MockWorkload)
+
+	mockWorkload.On("GetNamespace").Return("test-namespace")
+	mockWorkload.On("GetName").Return("test-workload")
+	mockWorkload.On("GetCreationTimestamp").Return(time.Now().Add(-scopeCli.GracePeriod))
+	mockWorkload.On("GetAnnotations").Return(map[string]string{
+		"downscaler/force-downtime": "true",
+	})
+	mockClient.On("DownscaleWorkload", values.AbsoluteReplicas(1), values.Replicas(values.AbsoluteReplicas(2)), mockWorkload, ctx).
+		Return(nil, nil)
+
 	err := scanWorkload(mockWorkload, mockClient, ctx, values.GetDefaultScope(), scopeCli, scopeEnv, namespaceScopes, namespaceMetrics, config)
 
 	require.NoError(t, err)

--- a/internal/api/kubernetes/admission/workloadMutationHandler.go
+++ b/internal/api/kubernetes/admission/workloadMutationHandler.go
@@ -391,7 +391,9 @@ setting different scaling states at the same time (e.g. downtime-period and upti
 			), err
 		}
 
-		response, err := mutateWorkload(workload, review, downscaleReplicas, dryRun, metricsEnabled, admissionMetrics)
+		minimumReplicas := scopes.GetMinimumReplicas()
+
+		response, err := mutateWorkload(workload, review, downscaleReplicas, minimumReplicas, dryRun, metricsEnabled, admissionMetrics)
 		if err != nil {
 			return response, err
 		}
@@ -479,6 +481,7 @@ func mutateWorkload(
 	workload scalable.Workload,
 	review *admissionv1.AdmissionReview,
 	downscaleReplicas values.Replicas,
+	minimumReplicas values.Replicas,
 	dryRun bool,
 	metricsEnabled bool,
 	admissionMetrics *metrics.AdmissionMetrics,
@@ -504,7 +507,7 @@ func mutateWorkload(
 		), err
 	}
 
-	_, err = workloadCopy.ScaleDown(downscaleReplicas)
+	_, err = workloadCopy.ScaleDown(downscaleReplicas, minimumReplicas)
 	if err != nil {
 		admissionMetrics.UpdateValidateWorkloadAdmissionRequestsTotal(metricsEnabled, false, true, workload.GetNamespace())
 

--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -53,7 +53,11 @@ type Client interface {
 	// RegetWorkload gets the workload again to ensure the latest state
 	RegetWorkload(workload scalable.Workload, ctx context.Context) error
 	// DownscaleWorkload downscales the workload to the specified replicas
-	DownscaleWorkload(replicas values.Replicas, workload scalable.Workload, ctx context.Context) (*metrics.SavedResources, error)
+	DownscaleWorkload(
+		replicas, minimumReplicas values.Replicas,
+		workload scalable.Workload,
+		ctx context.Context,
+	) (*metrics.SavedResources, error)
 	// UpscaleWorkload upscales the workload to the original replicas
 	UpscaleWorkload(workload scalable.Workload, ctx context.Context) error
 	// ensureSecret ensures that the secret used for storing TLS certificates exists
@@ -238,13 +242,17 @@ func (c client) RegetWorkload(workload scalable.Workload, ctx context.Context) e
 //
 
 func (c client) DownscaleWorkload(
-	replicas values.Replicas,
+	replicas, minimumReplicas values.Replicas,
 	workload scalable.Workload,
 	ctx context.Context,
 ) (*metrics.SavedResources, error) {
-	savedResources, err := workload.ScaleDown(replicas)
+	savedResources, err := workload.ScaleDown(replicas, minimumReplicas)
 	if err != nil {
 		return metrics.NewSavedResources(0, 0), fmt.Errorf("failed to set the workload into a scaled down state: %w", err)
+	}
+
+	if savedResources == nil {
+		return nil, nil //nolint:nilnil // skipped, below minimum
 	}
 
 	if c.dryRun {

--- a/internal/pkg/scalable/daemonsets.go
+++ b/internal/pkg/scalable/daemonsets.go
@@ -54,7 +54,7 @@ func (d *daemonSet) ScaleUp() error {
 }
 
 // ScaleDown scales the resource down.
-func (d *daemonSet) ScaleDown(_ values.Replicas) (*metrics.SavedResources, error) {
+func (d *daemonSet) ScaleDown(_, _ values.Replicas) (*metrics.SavedResources, error) {
 	if d.Spec.Template.Spec.NodeSelector == nil {
 		d.Spec.Template.Spec.NodeSelector = map[string]string{}
 	}

--- a/internal/pkg/scalable/daemonsets_test.go
+++ b/internal/pkg/scalable/daemonsets_test.go
@@ -122,7 +122,7 @@ func TestDaemonSet_ScaleDown(t *testing.T) {
 				daemonset.Spec.Template.Spec.NodeSelector = map[string]string{labelMatchNone: labelMatchNoneValue}
 			}
 
-			savedResources, err := daemonset.ScaleDown(values.AbsoluteReplicas(0))
+			savedResources, err := daemonset.ScaleDown(values.AbsoluteReplicas(0), nil)
 			require.NoError(t, err)
 
 			_, ok := daemonset.Spec.Template.Spec.NodeSelector[labelMatchNone]

--- a/internal/pkg/scalable/poddisruptionbudgets.go
+++ b/internal/pkg/scalable/poddisruptionbudgets.go
@@ -114,7 +114,7 @@ func (p *podDisruptionBudget) ScaleUp() error {
 }
 
 // ScaleDown scales the resource down.
-func (p *podDisruptionBudget) ScaleDown(downscaleReplicas values.Replicas) (*metrics.SavedResources, error) {
+func (p *podDisruptionBudget) ScaleDown(downscaleReplicas, _ values.Replicas) (*metrics.SavedResources, error) {
 	maxUnavailable := p.getMaxUnavailable()
 	if maxUnavailable != nil {
 		if maxUnavailable.String() == downscaleReplicas.String() {

--- a/internal/pkg/scalable/poddisruptionbudgets_test.go
+++ b/internal/pkg/scalable/poddisruptionbudgets_test.go
@@ -279,7 +279,7 @@ func TestPodDisruptionBudget_ScaleDown(t *testing.T) {
 				setOriginalReplicas(test.originalReplicas, pdb)
 			}
 
-			_, err := pdb.ScaleDown(values.AbsoluteReplicas(0))
+			_, err := pdb.ScaleDown(values.AbsoluteReplicas(0), nil)
 			require.NoError(t, err)
 
 			if test.wantMaxUnavailable != nil {

--- a/internal/pkg/scalable/replicaScaledWorkloads.go
+++ b/internal/pkg/scalable/replicaScaledWorkloads.go
@@ -63,8 +63,8 @@ func (r *replicaScaledWorkload) ScaleUp() error {
 
 // ScaleDown scales down the underlying replicaScaledResource.
 //
-
-func (r *replicaScaledWorkload) ScaleDown(downscaleReplicas values.Replicas) (*metrics.SavedResources, error) {
+//nolint:cyclop // mostly int32 conversions, can be cleaned up later
+func (r *replicaScaledWorkload) ScaleDown(downscaleReplicas, minimumReplicas values.Replicas) (*metrics.SavedResources, error) {
 	downscaleReplicasInt32, err := downscaleReplicas.AsInt32()
 	if err != nil {
 		return metrics.NewSavedResources(0, 0), fmt.Errorf("failed to convert replicas to int32: %w", err)
@@ -78,6 +78,18 @@ func (r *replicaScaledWorkload) ScaleDown(downscaleReplicas values.Replicas) (*m
 	currentReplicasInt32, err := currentReplicas.AsInt32()
 	if err != nil {
 		return metrics.NewSavedResources(0, 0), fmt.Errorf("failed to convert current replicas to int32: %w", err)
+	}
+
+	if minimumReplicas != nil {
+		minimumReplicasInt32, minErr := minimumReplicas.AsInt32()
+		if minErr != nil {
+			return metrics.NewSavedResources(0, 0), fmt.Errorf("failed to convert minimum replicas to int32: %w", minErr)
+		}
+
+		if currentReplicasInt32 < minimumReplicasInt32 {
+			slog.Debug("workload is below minimum replicas, skipping", "workload", r.GetName(), "namespace", r.GetNamespace())
+			return nil, nil //nolint:nilnil // skipped, below minimum
+		}
 	}
 
 	if currentReplicasInt32 == downscaleReplicasInt32 {

--- a/internal/pkg/scalable/replicaScaledWorkloads_test.go
+++ b/internal/pkg/scalable/replicaScaledWorkloads_test.go
@@ -100,8 +100,10 @@ func TestReplicaScaledWorkload_ScaleDown(t *testing.T) {
 		replicas             values.Replicas
 		originalReplicas     values.Replicas
 		downtimeReplicas     values.Replicas
+		minimumReplicas      values.Replicas
 		wantOriginalReplicas values.Replicas
 		wantReplicas         values.Replicas
+		wantSkipped          bool
 		wantSavedCPU         float64 // in cores
 		wantSavedMemory      float64 // in bytes
 		wantErr              error
@@ -147,6 +149,38 @@ func TestReplicaScaledWorkload_ScaleDown(t *testing.T) {
 			wantSavedMemory:      0.0,
 			wantErr:              &values.InvalidReplicaTypeError{},
 		},
+		{
+			name:                 "above minimum replicas, scales down",
+			replicas:             values.AbsoluteReplicas(3),
+			originalReplicas:     nil,
+			downtimeReplicas:     values.AbsoluteReplicas(1),
+			minimumReplicas:      values.AbsoluteReplicas(2),
+			wantOriginalReplicas: values.AbsoluteReplicas(3),
+			wantReplicas:         values.AbsoluteReplicas(1),
+			wantSavedCPU:         0.2,               // (3-1) replicas × 0.1 cores
+			wantSavedMemory:      128 * 1024 * 1024, // (3-1) replicas × 64Mi
+		},
+		{
+			name:                 "at minimum replicas, scales down",
+			replicas:             values.AbsoluteReplicas(2),
+			originalReplicas:     nil,
+			downtimeReplicas:     values.AbsoluteReplicas(1),
+			minimumReplicas:      values.AbsoluteReplicas(2),
+			wantOriginalReplicas: values.AbsoluteReplicas(2),
+			wantReplicas:         values.AbsoluteReplicas(1),
+			wantSavedCPU:         0.1,              // (2-1) replicas × 0.1 cores
+			wantSavedMemory:      64 * 1024 * 1024, // (2-1) replicas × 64Mi
+		},
+		{
+			name:                 "below minimum replicas, skipped",
+			replicas:             values.AbsoluteReplicas(1),
+			originalReplicas:     nil,
+			downtimeReplicas:     values.AbsoluteReplicas(1),
+			minimumReplicas:      values.AbsoluteReplicas(2),
+			wantOriginalReplicas: nil,
+			wantReplicas:         values.AbsoluteReplicas(1),
+			wantSkipped:          true,
+		},
 	}
 
 	for _, test := range tests {
@@ -175,7 +209,7 @@ func TestReplicaScaledWorkload_ScaleDown(t *testing.T) {
 				setOriginalReplicas(test.originalReplicas, workload)
 			}
 
-			savedResources, err := workload.ScaleDown(test.downtimeReplicas)
+			savedResources, err := workload.ScaleDown(test.downtimeReplicas, test.minimumReplicas)
 
 			if test.wantErr != nil {
 				var targetErr *values.InvalidReplicaTypeError
@@ -185,6 +219,20 @@ func TestReplicaScaledWorkload_ScaleDown(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+
+			if test.wantSkipped {
+				assert.Nil(t, savedResources)
+
+				gotReplicas, gerr := workload.getReplicas()
+				require.NoError(t, gerr)
+				assert.Equal(t, test.wantReplicas, gotReplicas)
+
+				_, origErr := getOriginalReplicas(workload)
+				var unsetErr *OriginalReplicasUnsetError
+				assert.ErrorAs(t, origErr, &unsetErr)
+
+				return
+			}
 
 			gotReplicas, err := workload.getReplicas()
 			require.NoError(t, err)

--- a/internal/pkg/scalable/suspendScaledWorkloads.go
+++ b/internal/pkg/scalable/suspendScaledWorkloads.go
@@ -37,7 +37,7 @@ func (r *suspendScaledWorkload) ScaleUp() error {
 // ScaleDown scales down the underlying suspendScaledResource.
 //
 
-func (r *suspendScaledWorkload) ScaleDown(_ values.Replicas) (*metrics.SavedResources, error) {
+func (r *suspendScaledWorkload) ScaleDown(_, _ values.Replicas) (*metrics.SavedResources, error) {
 	savedResources := r.getSavedResourcesRequests()
 
 	r.setSuspend(true)

--- a/internal/pkg/scalable/suspendScaledWorkloads_test.go
+++ b/internal/pkg/scalable/suspendScaledWorkloads_test.go
@@ -125,7 +125,7 @@ func TestSuspendScaledWorkload_ScaleDown(t *testing.T) {
 
 			s := suspendScaledWorkload{&cronjob}
 
-			savedResources, err := s.ScaleDown(nil)
+			savedResources, err := s.ScaleDown(nil, nil)
 			require.NoError(t, err)
 
 			assertBoolPointerEqual(t, test.wantSuspend, cronjob.Spec.Suspend)

--- a/internal/pkg/scalable/workload.go
+++ b/internal/pkg/scalable/workload.go
@@ -126,7 +126,7 @@ type Workload interface {
 	// ScaleUp scales up the workload
 	ScaleUp() error
 	// ScaleDown scales down the workload
-	ScaleDown(downscaleReplicas values.Replicas) (*metrics.SavedResources, error)
+	ScaleDown(downscaleReplicas, minimumReplicas values.Replicas) (*metrics.SavedResources, error)
 	// Copy creates a deep copy of the workload
 	Copy() (Workload, error)
 	// Compare compares the workload with another workload and returns the differences as a jsondiff.Patch

--- a/internal/pkg/values/scope.go
+++ b/internal/pkg/values/scope.go
@@ -47,6 +47,7 @@ func (s ScopeID) String() string {
 func NewScope() *Scope {
 	return &Scope{
 		DownscaleReplicas: nil,
+		MinimumReplicas:   nil,
 		GracePeriod:       util.Undefined,
 	}
 }
@@ -62,6 +63,7 @@ type Scope struct {
 	ForceUptime       timeSpans       // force workload into an uptime state when in one of the timespans
 	ForceDowntime     timeSpans       // force workload into a downtime state when in one of the timespans
 	DownscaleReplicas Replicas        // the replicas to scale down to
+	MinimumReplicas   Replicas        // the minimum replicas a workload has to have to be scaled down
 	GracePeriod       time.Duration   // grace period until new workloads will be scaled down
 	ScaleChildren     triStateBool    // ownerReference will immediately trigger scaling of children workloads, when applicable
 	UpscaleExcluded   triStateBool    // excluded workloads will be upscaled
@@ -80,6 +82,7 @@ func GetDefaultScope() *Scope {
 		ForceUptime:       nil,
 		ForceDowntime:     nil,
 		DownscaleReplicas: AbsoluteReplicas(0),
+		MinimumReplicas:   nil,
 		GracePeriod:       15 * time.Minute,
 		ScaleChildren:     triStateBool{isSet: false, value: false},
 		UpscaleExcluded:   triStateBool{isSet: false, value: false},
@@ -279,6 +282,19 @@ func (s Scopes) GetDownscaleReplicas() (Replicas, error) {
 	}
 
 	return nil, newValueNotSetError("downscaleReplicas")
+}
+
+// GetMinimumReplicas gets the minimum replicas of the first scope that implements minimum replicas.
+func (s Scopes) GetMinimumReplicas() Replicas {
+	for _, scope := range s {
+		if scope.MinimumReplicas == nil {
+			continue
+		}
+
+		return scope.MinimumReplicas
+	}
+
+	return nil
 }
 
 // GetScaleChildren gets the scale children of the first scope that implements scale children.

--- a/internal/pkg/values/scopeParser.go
+++ b/internal/pkg/values/scopeParser.go
@@ -21,6 +21,7 @@ const (
 	annotationForceUptime       = "downscaler/force-uptime"
 	annotationForceDowntime     = "downscaler/force-downtime"
 	annotationDownscaleReplicas = "downscaler/downscale-replicas"
+	annotationMinimumReplicas   = "downscaler/minimum-replicas"
 	annotationGracePeriod       = "downscaler/grace-period"
 	annotationScaleChildren     = "downscaler/scale-children"
 	annotationExclusionUpscale  = "downscaler/upscale-excluded"
@@ -80,6 +81,11 @@ func (s *Scope) ParseScopeFlags() {
 		&ReplicasValue{Replicas: &s.DownscaleReplicas},
 		"downtime-replicas",
 		"the replicas to scale down to (default: 0)",
+	)
+	flag.Var(
+		&ReplicasValue{Replicas: &s.MinimumReplicas},
+		"minimum-replicas",
+		"the minimum replicas a workload has to have to be scaled down (default: unset)",
 	)
 	flag.Var(
 		(*util.DurationValue)(&s.GracePeriod),
@@ -238,6 +244,19 @@ func (s *Scope) GetScopeFromAnnotations( //nolint: funlen,gocognit,cyclop,gocycl
 		}
 
 		s.DownscaleReplicas = *replicasVal.Replicas
+	}
+
+	if minimumReplicasString, ok := annotations[annotationMinimumReplicas]; ok {
+		minimumVal := ReplicasValue{Replicas: &s.MinimumReplicas}
+
+		if err = minimumVal.Set(minimumReplicasString); err != nil {
+			err = fmt.Errorf("failed to parse %q annotation: %w", annotationMinimumReplicas, err)
+			logEvent.ErrorInvalidAnnotation(annotationMinimumReplicas, err.Error(), ctx)
+
+			return err
+		}
+
+		s.MinimumReplicas = *minimumVal.Replicas
 	}
 
 	if gracePeriod, ok := annotations[annotationGracePeriod]; ok {

--- a/internal/pkg/values/scope_test.go
+++ b/internal/pkg/values/scope_test.go
@@ -1,12 +1,18 @@
 package values
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type noopResourceLogger struct{}
+
+func (noopResourceLogger) ErrorInvalidAnnotation(_, _ string, _ context.Context) {}
+func (noopResourceLogger) ErrorIncompatibleFields(_ string, _ context.Context)   {}
 
 func TestDefaultScopeIncompatible(t *testing.T) {
 	t.Parallel()
@@ -847,6 +853,115 @@ func TestGetWorkloadCreationTime(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestScope_GetScopeFromAnnotations_MinimumReplicas(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantReplica Replicas
+		wantErr     bool
+	}{
+		{
+			name:        "absolute integer",
+			annotations: map[string]string{"downscaler/minimum-replicas": "3"},
+			wantReplica: AbsoluteReplicas(3),
+		},
+		{
+			name:        "zero",
+			annotations: map[string]string{"downscaler/minimum-replicas": "0"},
+			wantReplica: AbsoluteReplicas(0),
+		},
+		{
+			name:        "garbage rejected",
+			annotations: map[string]string{"downscaler/minimum-replicas": "foo"},
+			wantErr:     true,
+		},
+		{
+			name:        "unset",
+			annotations: map[string]string{},
+			wantReplica: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			scope := NewScope()
+			err := scope.GetScopeFromAnnotations(test.annotations, noopResourceLogger{}, t.Context())
+
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.wantReplica, scope.MinimumReplicas)
+		})
+	}
+}
+
+func TestScopes_GetMinimumReplicas(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		scopes      Scopes
+		wantReplica Replicas
+	}{
+		{
+			name: "none set",
+			scopes: Scopes{
+				NewScope(), NewScope(), NewScope(), NewScope(), GetDefaultScope(),
+			},
+			wantReplica: nil,
+		},
+		{
+			name: "set on cli",
+			scopes: Scopes{
+				NewScope(),
+				NewScope(),
+				&Scope{MinimumReplicas: AbsoluteReplicas(3)},
+				NewScope(),
+				GetDefaultScope(),
+			},
+			wantReplica: AbsoluteReplicas(3),
+		},
+		{
+			name: "workload overrides lower scopes",
+			scopes: Scopes{
+				&Scope{MinimumReplicas: AbsoluteReplicas(5)},
+				&Scope{MinimumReplicas: AbsoluteReplicas(4)},
+				&Scope{MinimumReplicas: AbsoluteReplicas(3)},
+				NewScope(),
+				GetDefaultScope(),
+			},
+			wantReplica: AbsoluteReplicas(5),
+		},
+		{
+			name: "namespace overrides cli",
+			scopes: Scopes{
+				NewScope(),
+				&Scope{MinimumReplicas: AbsoluteReplicas(4)},
+				&Scope{MinimumReplicas: AbsoluteReplicas(3)},
+				NewScope(),
+				GetDefaultScope(),
+			},
+			wantReplica: AbsoluteReplicas(4),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := test.scopes.GetMinimumReplicas()
+			assert.Equal(t, test.wantReplica, got)
 		})
 	}
 }

--- a/website/content/docs/2 - downscaler/0 - scopes/2 - CLI Scope.mdx
+++ b/website/content/docs/2 - downscaler/0 - scopes/2 - CLI Scope.mdx
@@ -30,6 +30,7 @@ These global settings can be overridden by more specific scopes in the hierarchy
 - [--force-downtime](ref:docs-values#force-downtime)
 - [--force-uptime](ref:docs-values#force-uptime)
 - [--downtime-replicas](ref:docs-values#downscale-replicas)
+- [--minimum-replicas](ref:docs-values#minimum-replicas)
 - [--grace-period](ref:docs-values#grace-period)
 - [--explicit-include](ref:docs-values#exclude)
 - [--scale-children](ref:docs-values#scale-children)

--- a/website/content/docs/2 - downscaler/0 - scopes/3 - Namespace Scope.mdx
+++ b/website/content/docs/2 - downscaler/0 - scopes/3 - Namespace Scope.mdx
@@ -32,6 +32,7 @@ to apply scaling policies, exclusions and grace periods
 - [downscaler/force-uptime](ref:docs-values#force-uptime)
 - [downscaler/force-downtime](ref:docs-values#force-downtime)
 - [downscaler/downscale-replicas](ref:docs-values#downscale-replicas)
+- [downscaler/minimum-replicas](ref:docs-values#minimum-replicas)
 - [downscaler/grace-period](ref:docs-values#grace-period)
 - [downscaler/scale-children](ref:docs-values#scale-children)
 - [downscaler/upscale-excluded](ref:docs-values#upscale-excluded)

--- a/website/content/docs/2 - downscaler/0 - scopes/4 - Workload Scope.mdx
+++ b/website/content/docs/2 - downscaler/0 - scopes/4 - Workload Scope.mdx
@@ -33,6 +33,7 @@ scaling policies, exclusions and grace periods
 - [downscaler/force-uptime](ref:docs-values#force-uptime)
 - [downscaler/force-downtime](ref:docs-values#force-downtime)
 - [downscaler/downscale-replicas](ref:docs-values#downscale-replicas)
+- [downscaler/minimum-replicas](ref:docs-values#minimum-replicas)
 - [downscaler/grace-period](ref:docs-values#grace-period)
 - [downscaler/scale-children](ref:docs-values#scale-children)
 - [downscaler/upscale-excluded](ref:docs-values#upscale-excluded)

--- a/website/content/docs/2 - downscaler/1 - configurations/1 - Values.mdx
+++ b/website/content/docs/2 - downscaler/1 - configurations/1 - Values.mdx
@@ -177,6 +177,16 @@ Here is a list of all values that can be set on the Downscaler.
 - Where to set: [CLI Scope](ref:docs-cli-scope#values), [Namespace Scope](ref:docs-namespace-scope#values),
   [Workload Scope](ref:docs-workload-scope#values)
 
+### Minimum Replicas
+
+- Type: [Replicas](ref:docs-replicas)
+- Default: unset
+- The minimum replicas a [workload](ref:docs-workload-types) has to have to be scaled down.
+  Workloads with fewer current replicas are skipped during downscaling.
+  Only applies to replica-scaled workloads.
+- Where to set: [CLI Scope](ref:docs-cli-scope#values), [Namespace Scope](ref:docs-namespace-scope#values),
+  [Workload Scope](ref:docs-workload-scope#values)
+
 ### Grace Period
 
 - Type: [Duration](ref:docs-duration)


### PR DESCRIPTION
## Motivation

We run a multi-tenant Kubernetes cluster used by a lot of development teams. Some of them temporarily scale their deployments down to 0 replicas for their own reasons, and we don't want the downscaler to mess with that.

We're running with `--downtime-replicas=1` right now, which means the downscaler sets every matched workload to 1 during downtime. So a deployment a team had manually scaled to 0 actually gets scaled back up to 1, which is exactly the wrong direction.

This PR adds a `minimum-replicas` threshold. If a workload has fewer current replicas then the threshold, the downscaler skips it. So with `--downtime-replicas=1 --minimum-replicas=1`:

- 0 replicas: left alone (used to get scaled up to 1, which was the actual bug for us)
- 1 replica: already at the target, nothing to do
- 2 replicas: scaled to 1

## Changes

- New `MinimumReplicas` field on `Scope`, with the usual scope-hierarchy resolver (`Scopes.GetMinimumReplicas()`).
- New `--minimum-replicas` flag and `downscaler/minimum-replicas` annotation, reusing the existing `ReplicasValue` parser.
- `Workload.ScaleDown` now takes a second `minimumReplicas` arg. Only `replicaScaledWorkload` actually uses it; daemonsets, PDBs and suspend-scaled workloads ignore it.
- When the workload is below the threshold, `ScaleDown` returns `(nil, nil)` and the caller counts it as excluded.
- Docs: added a `Minimum Replicas` entry in `Values.mdx` and a link from each of the three scope pages.

## Tests Done

- `go test -race ./...` and `golangci-lint run` are both green.
- Added unit tests for annotation parsing, scope-precedence resolution, the `ScaleDown` threshold logic (above/at/below), and one integration test through `scanWorkload`.