### PR TITLE
Fix/Skip workloads below downtime-replicas

### DIFF
--- a/internal/pkg/scalable/replicaScaledWorkloads.go
+++ b/internal/pkg/scalable/replicaScaledWorkloads.go
@@ -80,7 +80,7 @@ func (r *replicaScaledWorkload) ScaleDown(downscaleReplicas values.Replicas) (*m
 		return metrics.NewSavedResources(0, 0), fmt.Errorf("failed to convert current replicas to int32: %w", err)
 	}
 
-	if currentReplicasInt32 == downscaleReplicasInt32 {
+	if currentReplicasInt32 <= downscaleReplicasInt32 {
 		var originalReplicasInt32 int32
 		var isOriginalReplicasSet bool
 
@@ -90,7 +90,7 @@ func (r *replicaScaledWorkload) ScaleDown(downscaleReplicas values.Replicas) (*m
 		}
 
 		if !isOriginalReplicasSet {
-			slog.Debug("workload is already at target scale down replicas, skipping", "workload", r.GetName(), "namespace", r.GetNamespace())
+			slog.Debug("workload is at or below target scale down replicas, skipping", "workload", r.GetName(), "namespace", r.GetNamespace())
 			return metrics.NewSavedResources(0, 0), nil
 		}
 

--- a/internal/pkg/scalable/replicaScaledWorkloads_test.go
+++ b/internal/pkg/scalable/replicaScaledWorkloads_test.go
@@ -147,6 +147,16 @@ func TestReplicaScaledWorkload_ScaleDown(t *testing.T) {
 			wantSavedMemory:      0.0,
 			wantErr:              &values.InvalidReplicaTypeError{},
 		},
+		{
+			name:                 "current replicas below downtime replicas",
+			replicas:             values.AbsoluteReplicas(0),
+			originalReplicas:     nil,
+			downtimeReplicas:     values.AbsoluteReplicas(1),
+			wantOriginalReplicas: nil,
+			wantReplicas:         values.AbsoluteReplicas(0),
+			wantSavedCPU:         0.0,
+			wantSavedMemory:      0.0,
+		},
 	}
 
 	for _, test := range tests {
@@ -191,7 +201,12 @@ func TestReplicaScaledWorkload_ScaleDown(t *testing.T) {
 			assert.Equal(t, test.wantReplicas, gotReplicas)
 
 			gotOriginal, err := getOriginalReplicas(workload)
-			require.NoError(t, err)
+			var unsetErr *OriginalReplicasUnsetError
+
+			if !errors.As(err, &unsetErr) {
+				require.NoError(t, err)
+			}
+
 			assert.Equal(t, test.wantOriginalReplicas, gotOriginal)
 
 			assert.InDelta(t, test.wantSavedCPU, savedResources.TotalCPU(), 0.0001)    // CPU tolerance


### PR DESCRIPTION
## Motivation

We run a multi-tenant Kubernetes cluster used by a lot of development teams. Some of them temporarily scale their deployments down to 0 replicas for their own reasons, and we don't want the downscaler to mess with that.

We're running with --downtime-replicas=1 right now, which means the downscaler sets every matched workload to 1 during downtime. So a deployment a team had manually scaled to 0 actually gets scaled back up to 1, which is exactly the wrong direction.

I checked py-kube-downscaler and it doesn't have this issue. Its downscale branch is gated by `replicas > downtime_replicas`, so worklaods at or below the target are skipped. This PR fixes the bug which was initially worked around in #455.

## Changes

- Fixed the bug in `replicaScaledWorkload.ScaleDown`.
- Added a regression test.

## Tests Done

- `go test -race ./...` and `golangci-lint run` both green.
