### PR TITLE
perf(client): skip Update API call when workload is already in desired state

### DIFF
--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -242,9 +243,29 @@ func (c client) DownscaleWorkload(
 	workload scalable.Workload,
 	ctx context.Context,
 ) (*metrics.SavedResources, error) {
+	original, copyErr := workload.Copy()
+	if copyErr != nil {
+		slog.Debug(
+			"failed to snapshot workload before scale down, will update unconditionally",
+			"workload", workload.GetName(),
+			"namespace", workload.GetNamespace(),
+			"error", copyErr,
+		)
+	}
+
 	savedResources, err := workload.ScaleDown(replicas)
 	if err != nil {
 		return metrics.NewSavedResources(0, 0), fmt.Errorf("failed to set the workload into a scaled down state: %w", err)
+	}
+
+	if original != nil && reflect.DeepEqual(original, workload) {
+		slog.Debug(
+			"workload already in desired scaled down state, skipping update",
+			"workload", workload.GetName(),
+			"namespace", workload.GetNamespace(),
+		)
+
+		return savedResources, nil
 	}
 
 	if c.dryRun {
@@ -269,9 +290,29 @@ func (c client) DownscaleWorkload(
 
 // UpscaleWorkload upscales the workload to the original replicas.
 func (c client) UpscaleWorkload(workload scalable.Workload, ctx context.Context) error {
+	original, copyErr := workload.Copy()
+	if copyErr != nil {
+		slog.Debug(
+			"failed to snapshot workload before scale up, will update unconditionally",
+			"workload", workload.GetName(),
+			"namespace", workload.GetNamespace(),
+			"error", copyErr,
+		)
+	}
+
 	err := workload.ScaleUp()
 	if err != nil {
 		return fmt.Errorf("failed to set the workload into a scaled up state: %w", err)
+	}
+
+	if original != nil && reflect.DeepEqual(original, workload) {
+		slog.Debug(
+			"workload already in desired scaled up state, skipping update",
+			"workload", workload.GetName(),
+			"namespace", workload.GetNamespace(),
+		)
+
+		return nil
 	}
 
 	if c.dryRun {

--- a/internal/api/kubernetes/client_test.go
+++ b/internal/api/kubernetes/client_test.go
@@ -1,0 +1,116 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/caas-team/gokubedownscaler/internal/pkg/scalable"
+	"github.com/caas-team/gokubedownscaler/internal/pkg/values"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const annotationOriginalReplicas = "downscaler/original-replicas"
+
+func newClientWithDeployment(t *testing.T, dep *appsv1.Deployment) (client, scalable.Workload) {
+	t.Helper()
+
+	fakeKube := fake.NewClientset(dep)
+	c := client{
+		clientsets: &scalable.Clientsets{Kubernetes: fakeKube},
+	}
+
+	workloads, err := scalable.GetWorkloads("deployments", dep.Namespace, c.clientsets, context.Background())
+	require.NoError(t, err)
+	require.Len(t, workloads, 1)
+
+	return c, workloads[0]
+}
+
+func countUpdateActions(c client) int {
+	count := 0
+	for _, action := range c.clientsets.Kubernetes.(*fake.Clientset).Actions() {
+		if action.GetVerb() == "update" {
+			count++
+		}
+	}
+
+	return count
+}
+
+func TestDownscaleWorkload_SkipsUpdateWhenAlreadyDownscaled(t *testing.T) {
+	t.Parallel()
+
+	zero := int32(0)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "already-down",
+			Namespace:   "ns",
+			Annotations: map[string]string{annotationOriginalReplicas: "5"},
+		},
+		Spec: appsv1.DeploymentSpec{Replicas: &zero},
+	}
+
+	c, workload := newClientWithDeployment(t, dep)
+
+	_, err := c.DownscaleWorkload(values.AbsoluteReplicas(0), workload, context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, countUpdateActions(c), "Update API should not be called when workload is already in desired state")
+}
+
+func TestDownscaleWorkload_CallsUpdateWhenScalingRequired(t *testing.T) {
+	t.Parallel()
+
+	five := int32(5)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "to-down", Namespace: "ns"},
+		Spec:       appsv1.DeploymentSpec{Replicas: &five},
+	}
+
+	c, workload := newClientWithDeployment(t, dep)
+
+	_, err := c.DownscaleWorkload(values.AbsoluteReplicas(0), workload, context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, countUpdateActions(c), "Update API should be called when replicas change")
+}
+
+func TestUpscaleWorkload_SkipsUpdateWhenNoOriginalReplicasAnnotation(t *testing.T) {
+	t.Parallel()
+
+	five := int32(5)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "already-up", Namespace: "ns"},
+		Spec:       appsv1.DeploymentSpec{Replicas: &five},
+	}
+
+	c, workload := newClientWithDeployment(t, dep)
+
+	require.NoError(t, c.UpscaleWorkload(workload, context.Background()))
+
+	assert.Equal(t, 0, countUpdateActions(c), "Update API should not be called when there is nothing to restore")
+}
+
+func TestUpscaleWorkload_CallsUpdateWhenRestoringReplicas(t *testing.T) {
+	t.Parallel()
+
+	zero := int32(0)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "to-up",
+			Namespace:   "ns",
+			Annotations: map[string]string{annotationOriginalReplicas: "5"},
+		},
+		Spec: appsv1.DeploymentSpec{Replicas: &zero},
+	}
+
+	c, workload := newClientWithDeployment(t, dep)
+
+	require.NoError(t, c.UpscaleWorkload(workload, context.Background()))
+
+	assert.Equal(t, 1, countUpdateActions(c), "Update API should be called when restoring replicas")
+}

--- a/internal/pkg/scalable/workload.go
+++ b/internal/pkg/scalable/workload.go
@@ -134,7 +134,7 @@ type Workload interface {
 }
 
 type Clientsets struct {
-	Kubernetes *kubernetes.Clientset
+	Kubernetes kubernetes.Interface
 	Keda       *keda.Clientset
 	Argo       *argo.Clientset
 	Zalando    *zalando.Clientset


### PR DESCRIPTION
## Problem

Each scan iteration currently issues a Kubernetes `Update` API call against every targeted workload — **even when the workload is already in the desired state** (already downscaled, or already at its original replicas).

Concrete consequences:

- **Audit log spam**: in a cluster with hundreds of managed workloads, every scan interval (default 30s) produces hundreds of audit entries that record no actual change.
- **resourceVersion churn**: every workload's `resourceVersion` is incremented on every scan, which can confuse other controllers and trip optimistic concurrency loops elsewhere.
- **Unnecessary API server load**: full `Update` requests with their admission/validation pipelines run for nothing.

The existing short-circuit inside `ScaleDown` ([replicaScaledWorkloads.go:83-102](https://github.com/gaetanars/GoKubeDownscaler/blob/main/internal/pkg/scalable/replicaScaledWorkloads.go#L83-L102)) only covers a narrow case: workload already at the target replica count **and** no `original-replicas` annotation. In the much more common case (already downscaled **with** annotation set, or any CronJob/Job already suspended, or any DaemonSet already with the match-none label), the in-memory mutation is a no-op but `client.Update()` is still called.

## Fix

Snapshot the workload via the existing `Workload.Copy()` method **before** mutating, then compare with `reflect.DeepEqual` **after**. If nothing actually changed, log a `debug` message and skip the `Update` API call entirely.

```go
original, copyErr := workload.Copy()
// ... ScaleDown / ScaleUp ...
if original != nil && reflect.DeepEqual(original, workload) {
    slog.Debug("workload already in desired state, skipping update", ...)
    return savedResources, nil
}
err = workload.Update(c.clientsets, ctx)
```

### Why this approach

| Approach considered | Verdict |
|---|---|
| Add `changed bool` return to `ScaleUp`/`ScaleDown` on the `Workload` interface | Rejected — touches 12 implementations + admission controller + ~28 tests |
| Switch `Update` to `Patch` (JSON merge / strategic) | Rejected — does **not** remove the audit log entry; root problem persists |
| **Snapshot + `reflect.DeepEqual` in the client (this PR)** | **Chosen** — zero interface change, automatic coverage for any future `Workload` implementation |

### Properties

- **Generic**: works for every resource type without special-casing (Deployment, StatefulSet, HPA, KEDA `ScaledObject`, CronJob, DaemonSet, PDB, Argo Rollout, Prometheus, AutoscalingRunnerSet, Zalando Stack, Job).
- **Safe fallback**: if `Copy()` ever returns an error, we fall back to the previous behavior (unconditional `Update`). No regression risk.
- **Cheap**: one deep-copy + one `DeepEqual` per workload per scan. Negligible compared to the network round-trip we're avoiding.

## Secondary change

`Clientsets.Kubernetes` widened from `*kubernetes.Clientset` to `kubernetes.Interface`. All call sites already use only interface methods, so this is transparent at runtime. It enables injecting `k8s.io/client-go/kubernetes/fake` in tests.

## Tests

New `internal/api/kubernetes/client_test.go` with four cases asserting the exact number of `update` actions recorded by the fake clientset:

| Scenario | Expected `Update` calls |
|---|---|
| Deployment already at 0 replicas with correct `original-replicas` annotation → `DownscaleWorkload(0)` | **0** |
| Deployment at 5 replicas → `DownscaleWorkload(0)` | 1 |
| Deployment at 5 replicas, no annotation → `UpscaleWorkload` | **0** |
| Deployment at 0 replicas with annotation → `UpscaleWorkload` | 1 |

## Validation

- `go test --cover ./...` — all packages green
- `go vet ./...` — clean

## Test plan

- [ ] CI green
- [ ] Manual test on a dev cluster: deploy with several already-downscaled workloads, observe that audit log entries on the second+ scan drop to zero for unchanged workloads
- [ ] Confirm `--dry-run` still logs `"would have sent update"` only for workloads that would actually change

🤖 Generated with [Claude Code](https://claude.com/claude-code)