### PR TITLE
New Resource: zalando postgresql (`acid.zalan.do/v1`)

### DIFF
--- a/deployments/chart/templates/_helpers.tpl
+++ b/deployments/chart/templates/_helpers.tpl
@@ -143,7 +143,6 @@ Create defined permissions for the webhook clusterrole
     - webhook.kube-downscaler.k8s
   verbs:
     - get
-    - watch
     - patch
     - update
 {{- end }}

--- a/deployments/chart/templates/_helpers.tpl
+++ b/deployments/chart/templates/_helpers.tpl
@@ -80,15 +80,18 @@ Create selector label for the webhook
 Create defined permissions for the webhook role
 */}}
 {{- define "go-kube-downscaler.webhookController.namespace.permissions" -}}
-# "create" cannot be restricted by resourceNames (the object does not exist yet, so the
-# API server ignores resourceNames-scoped rules for create). It must be a separate
-# unrestricted rule, scoped here only by the namespace of this Role.
+# "create", "list" and "watch" cannot be restricted by resourceNames: create has no object
+# to name-match yet, and the controller's reflector lists+watches the collection before it
+# can filter by name. These must be unrestricted, scoped only by this Role's namespace. The
+# name-scoped rule keeps the verbs that act on our specific secret (get/update/patch).
 - apiGroups:
     - ""
   resources:
     - secrets
   verbs:
     - create
+    - list
+    - watch
 - apiGroups:
     - ""
   resources:
@@ -96,11 +99,9 @@ Create defined permissions for the webhook role
   resourceNames:
     - {{ include "go-kube-downscaler.fullname" . }}-webhook
   verbs:
+    - get
     - update
     - patch
-    - get
-    - watch
-    - list
 - apiGroups:
     - coordination.k8s.io
   resources:

--- a/deployments/chart/templates/_helpers.tpl
+++ b/deployments/chart/templates/_helpers.tpl
@@ -80,6 +80,15 @@ Create selector label for the webhook
 Create defined permissions for the webhook role
 */}}
 {{- define "go-kube-downscaler.webhookController.namespace.permissions" -}}
+# "create" cannot be restricted by resourceNames (the object does not exist yet, so the
+# API server ignores resourceNames-scoped rules for create). It must be a separate
+# unrestricted rule, scoped here only by the namespace of this Role.
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - create
 - apiGroups:
     - ""
   resources:
@@ -87,7 +96,6 @@ Create defined permissions for the webhook role
   resourceNames:
     - {{ include "go-kube-downscaler.fullname" . }}-webhook
   verbs:
-    - create
     - update
     - patch
     - get

--- a/deployments/chart/templates/_helpers.tpl
+++ b/deployments/chart/templates/_helpers.tpl
@@ -285,6 +285,16 @@ Create defined permissions for roles
     - list
     - update
 {{- end }}
+{{- if eq $resource "postgresqls" }}
+- apiGroups:
+    - acid.zalan.do
+  resources:
+    - postgresqls
+  verbs:
+    - get
+    - list
+    - update
+{{- end }}
 {{- end }}
 {{- end }}
 
@@ -424,6 +434,17 @@ Create webhook resources
     - "UPDATE"
   resources:
     - autoscalingrunnersets
+{{ end -}}
+{{ if eq $resource "postgresqls" -}}
+- apiGroups:
+    - acid.zalan.do
+  apiVersions:
+    - "*"
+  operations:
+    - "CREATE"
+    - "UPDATE"
+  resources:
+    - postgresqls
 {{ end -}}
 {{ end -}}
 {{- end }}
@@ -590,6 +611,19 @@ resources include in annotationsCompliance
     - "UPDATE"
   resources:
     - autoscalingrunnersets
+{{ end -}}
+{{ if eq $resource "postgresqls" -}}
+- apiGroups:
+    - acid.zalan.do
+  apiVersions:
+    - "*"
+  operations:
+  {{- if $createUpdate }}
+    - "CREATE"
+  {{- end }}
+    - "UPDATE"
+  resources:
+    - postgresqls
 {{ end -}}
 {{ end -}}
 {{- end }}

--- a/deployments/chart/templates/_helpers.tpl
+++ b/deployments/chart/templates/_helpers.tpl
@@ -124,6 +124,16 @@ Create defined permissions for the webhook clusterrole
     - namespaces
   verbs:
     - get
+# "list"/"watch" cannot be restricted by resourceNames (the controller's reflector lists
+# the collection before watching), so they need an unrestricted rule. The name-scoped rule
+# below keeps the mutating verbs (get/patch/update) limited to our own webhook config.
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+  verbs:
+    - list
+    - watch
 - apiGroups:
     - admissionregistration.k8s.io
   resources:

--- a/deployments/chart/templates/webhookdeployment.yaml
+++ b/deployments/chart/templates/webhookdeployment.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-webhook
-          image: "{{ .Values.webhookController.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.webhookController.image.repository }}:{{ .Values.webhookController.image.tag | default .Chart.AppVersion }}"
           args:
           {{- with .Values.arguments }}
           {{- toYaml . | nindent 10 }}

--- a/deployments/chart/values.yaml
+++ b/deployments/chart/values.yaml
@@ -26,6 +26,7 @@ includedResources:
 #  - poddisruptionbudgets
 #  - prometheuses
 #  - autoscalingrunnersets
+#  - postgresqls
 
 fullnameOverride: ""
 nameOverride: ""

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/wI2L/jsondiff v0.7.0
 	github.com/zalando-incubator/stackset-controller v1.4.126
+	github.com/zalando/postgres-operator v1.15.1
 	go.uber.org/zap v1.27.1
 	k8s.io/api v0.35.5
 	k8s.io/apimachinery v0.35.5
@@ -63,15 +64,18 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
+	github.com/motomux/pretty v0.0.0-20161209205251-b2aad2c9a95d // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v1.20.99 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/szuecs/routegroup-client v0.34.1 // indirect
@@ -97,6 +101,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/actions/actions-runner-controller v0.27.6 h1:Uklv1+6+/BQuhV6HoXIgPZrnAW9/HWo3j9O7IcnzGXU=
@@ -16,6 +17,7 @@ github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -136,6 +138,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/motomux/pretty v0.0.0-20161209205251-b2aad2c9a95d h1:LznySqW8MqVeFh+pW6rOkFdld9QQ7jRydBKKM6jyPVI=
+github.com/motomux/pretty v0.0.0-20161209205251-b2aad2c9a95d/go.mod h1:u3hJ0kqCQu/cPpsu3RbCOPZ0d7V3IjPjv1adNRleM9I=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
@@ -203,6 +207,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zalando-incubator/stackset-controller v1.4.126 h1:jLlPgamQrxfodglDr1zuZNFQsESwIvUQSqjyJHAgLCs=
 github.com/zalando-incubator/stackset-controller v1.4.126/go.mod h1:29RbiSjtQH8psQempEAxuZyCVY6aKmYGIa0b0JU2+d0=
+github.com/zalando/postgres-operator v1.15.1 h1:WjZA6KySmDw4bpY77lk/5P+vYCAf2xMCmVl/EOyu7Ww=
+github.com/zalando/postgres-operator v1.15.1/go.mod h1:pXM8YFzLgrFdsmhypHsWGJcA2zQkhFA+B9fwqnj7tYw=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
 go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 go.etcd.io/etcd/api/v3 v3.6.7 h1:7BNJ2gQmc3DNM+9cRkv7KkGQDayElg8x3X+tFDYS+E0=

--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -19,6 +19,7 @@ import (
 	keda "github.com/kedacore/keda/v2/pkg/generated/clientset/versioned"
 	monitoring "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	zalando "github.com/zalando-incubator/stackset-controller/pkg/clientset"
+	acidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -148,6 +149,12 @@ func NewScheme() (*runtime.Scheme, error) {
 	err := actionsv1alpha1.AddToScheme(scheme)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add a scheme to generic client: %w", err)
+	}
+
+	// Zalando postgres-operator CRDs
+	err = acidv1.AddToScheme(scheme)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add acidv1 scheme to generic client: %w", err)
 	}
 
 	return scheme, nil

--- a/internal/pkg/scalable/postgresqls.go
+++ b/internal/pkg/scalable/postgresqls.go
@@ -1,0 +1,158 @@
+//nolint:dupl // necessary to handle different workload types separately
+package scalable
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/caas-team/gokubedownscaler/internal/pkg/metrics"
+	"github.com/caas-team/gokubedownscaler/internal/pkg/values"
+	"github.com/wI2L/jsondiff"
+	acidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// getPostgresqls is the getResourceFunc for Zalando postgres-operator Postgresqls.
+func getPostgresqls(namespace string, clientsets *Clientsets, ctx context.Context) ([]Workload, error) {
+	var postgresqls acidv1.PostgresqlList
+
+	err := clientsets.Client.List(ctx, &postgresqls, ctrlclient.InNamespace(namespace))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get postgresqls: %w", err)
+	}
+
+	results := make([]Workload, 0, len(postgresqls.Items))
+	for i := range postgresqls.Items {
+		results = append(results, &replicaScaledWorkload{&postgresql{&postgresqls.Items[i]}})
+	}
+
+	return results, nil
+}
+
+// parsePostgresqlFromBytes parses the admission review and returns the postgresql wrapped in a Workload.
+func parsePostgresqlFromBytes(rawObject []byte) (Workload, error) {
+	var pg acidv1.Postgresql
+	if err := json.Unmarshal(rawObject, &pg); err != nil {
+		return nil, fmt.Errorf("failed to decode postgresql: %w", err)
+	}
+
+	return &replicaScaledWorkload{&postgresql{&pg}}, nil
+}
+
+// postgresql is a wrapper for postgresql.v1.acid.zalan.do to implement the replicaScaledResource interface.
+type postgresql struct {
+	*acidv1.Postgresql
+}
+
+func (p *postgresql) Reget(clientsets *Clientsets, ctx context.Context) error {
+	err := clientsets.Client.Get(ctx, ctrlclient.ObjectKey{Namespace: p.Namespace, Name: p.Name}, p.Postgresql)
+	if err != nil {
+		return fmt.Errorf("failed to get postgresql: %w", err)
+	}
+
+	return nil
+}
+
+// Update writes the spec changes back. It updates the main resource only; the postgresql status is a
+// subresource and is left untouched by the apiserver on a main-resource update.
+func (p *postgresql) Update(clientsets *Clientsets, ctx context.Context) error {
+	err := clientsets.Client.Update(ctx, p.Postgresql)
+	if err != nil {
+		return fmt.Errorf("failed to update postgresql: %w", err)
+	}
+
+	return nil
+}
+
+// setReplicas sets the amount of replicas on the resource. Changes won't be made on Kubernetes until update() is called.
+func (p *postgresql) setReplicas(replicas int32) error {
+	p.Spec.NumberOfInstances = replicas
+	return nil
+}
+
+// getReplicas gets the current amount of replicas of the resource.
+//
+// NumberOfInstances is a value int32 (not a pointer), so it can never be nil and there is no
+// newNoReplicasError case like statefulsets/stacks have. The error return is kept only to satisfy
+// the replicaScaledResource interface and is always nil here.
+func (p *postgresql) getReplicas() (values.Replicas, error) {
+	return values.AbsoluteReplicas(p.Spec.NumberOfInstances), nil
+}
+
+// getSavedResourcesRequests calculates the total saved resources requests when downscaling the Postgresql.
+//
+// Unlike pod-template based workloads, the Postgresql CR describes the per-instance request once via the
+// embedded *Resources block (often nil). Savings are that per-instance request multiplied by the diff in
+// instances. Parse failures are treated as zero so resource accounting never breaks a scale operation.
+func (p *postgresql) getSavedResourcesRequests(diffReplicas int32) *metrics.SavedResources {
+	totalSavedCPU, totalSavedMemory := float64(0), float64(0)
+
+	if p.Spec.Resources != nil {
+		requests := p.Spec.ResourceRequests
+		totalSavedCPU = parseQuantityAsFloat(requests.CPU)
+		totalSavedMemory = parseQuantityAsFloat(requests.Memory)
+	}
+
+	totalSavedCPU *= float64(diffReplicas)
+	totalSavedMemory *= float64(diffReplicas)
+
+	return metrics.NewSavedResources(totalSavedCPU, totalSavedMemory)
+}
+
+// parseQuantityAsFloat parses an optional Kubernetes quantity string into a float64.
+// A nil pointer or an unparseable value yields 0 so resource accounting never breaks a scale operation.
+func parseQuantityAsFloat(quantity *string) float64 {
+	if quantity == nil {
+		return 0
+	}
+
+	parsed, err := resource.ParseQuantity(*quantity)
+	if err != nil {
+		return 0
+	}
+
+	return parsed.AsApproximateFloat64()
+}
+
+// Copy creates a deep copy of the given Workload, which is expected to be a replicaScaledWorkload wrapping a postgresql.
+func (p *postgresql) Copy() (Workload, error) {
+	if p.Postgresql == nil {
+		return nil, newNilUnderlyingObjectError(p.Kind)
+	}
+
+	copied := p.DeepCopy()
+
+	return &replicaScaledWorkload{
+		replicaScaledResource: &postgresql{
+			Postgresql: copied,
+		},
+	}, nil
+}
+
+// Compare compares two postgresql resources and returns the differences as a jsondiff.Patch.
+//
+//nolint:varnamelen //required for interface-based workflow
+func (p *postgresql) Compare(workloadCopy Workload) (jsondiff.Patch, error) {
+	rswCopy, ok := workloadCopy.(*replicaScaledWorkload)
+	if !ok {
+		return nil, newExpectTypeGotTypeError((*replicaScaledWorkload)(nil), workloadCopy)
+	}
+
+	pgCopy, ok := rswCopy.replicaScaledResource.(*postgresql)
+	if !ok {
+		return nil, newExpectTypeGotTypeError((*postgresql)(nil), rswCopy.replicaScaledResource)
+	}
+
+	if p.Postgresql == nil || pgCopy.Postgresql == nil {
+		return nil, newNilUnderlyingObjectError(p.Kind)
+	}
+
+	diff, err := jsondiff.Compare(p.Postgresql, pgCopy.Postgresql)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compare postgresqls: %w", err)
+	}
+
+	return diff, nil
+}

--- a/internal/pkg/scalable/postgresqls_test.go
+++ b/internal/pkg/scalable/postgresqls_test.go
@@ -1,0 +1,273 @@
+package scalable
+
+import (
+	"testing"
+
+	"github.com/caas-team/gokubedownscaler/internal/pkg/values"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	acidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func strPtr(value string) *string { return &value }
+
+func TestPostgresql_SetGetReplicas(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		numberOfInstance int32
+		setTo            int32
+		wantAfterSet     values.Replicas
+	}{
+		{
+			name:             "set replicas to zero from non-zero",
+			numberOfInstance: 3,
+			setTo:            0,
+			wantAfterSet:     values.AbsoluteReplicas(0),
+		},
+		{
+			name:             "set replicas to non-zero from zero value",
+			numberOfInstance: 0,
+			setTo:            5,
+			wantAfterSet:     values.AbsoluteReplicas(5),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			pgResource := &postgresql{&acidv1.Postgresql{}}
+			pgResource.Spec.NumberOfInstances = test.numberOfInstance
+
+			// getReplicas never errors for postgresql (NumberOfInstances is a value int32).
+			gotInitial, err := pgResource.getReplicas()
+			require.NoError(t, err)
+			assert.Equal(t, values.AbsoluteReplicas(test.numberOfInstance), gotInitial)
+
+			err = pgResource.setReplicas(test.setTo)
+			require.NoError(t, err)
+
+			gotAfterSet, err := pgResource.getReplicas()
+			require.NoError(t, err)
+			assert.Equal(t, test.wantAfterSet, gotAfterSet)
+		})
+	}
+}
+
+func TestPostgresql_GetSavedResourcesRequests(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		resources    *acidv1.Resources
+		diffReplicas int32
+		wantCPU      float64 // in cores
+		wantMemory   float64 // in bytes
+	}{
+		{
+			name:         "no resources block",
+			resources:    nil,
+			diffReplicas: 3,
+			wantCPU:      0,
+			wantMemory:   0,
+		},
+		{
+			name: "cpu and memory set",
+			resources: &acidv1.Resources{
+				ResourceRequests: acidv1.ResourceDescription{
+					CPU:    strPtr("500m"),
+					Memory: strPtr("1Gi"),
+				},
+			},
+			diffReplicas: 3,
+			wantCPU:      1.5,                    // 3 × 0.5 cores
+			wantMemory:   3 * 1024 * 1024 * 1024, // 3 × 1Gi
+		},
+		{
+			name: "only cpu set, memory nil",
+			resources: &acidv1.Resources{
+				ResourceRequests: acidv1.ResourceDescription{
+					CPU: strPtr("250m"),
+				},
+			},
+			diffReplicas: 2,
+			wantCPU:      0.5, // 2 × 0.25 cores
+			wantMemory:   0,
+		},
+		{
+			name: "unparseable cpu treated as zero",
+			resources: &acidv1.Resources{
+				ResourceRequests: acidv1.ResourceDescription{
+					CPU:    strPtr("not-a-quantity"),
+					Memory: strPtr("64Mi"),
+				},
+			},
+			diffReplicas: 1,
+			wantCPU:      0,
+			wantMemory:   64 * 1024 * 1024,
+		},
+		{
+			name: "unparseable memory treated as zero",
+			resources: &acidv1.Resources{
+				ResourceRequests: acidv1.ResourceDescription{
+					CPU:    strPtr("250m"),
+					Memory: strPtr("not-a-quantity"),
+				},
+			},
+			diffReplicas: 1,
+			wantCPU:      0.25,
+			wantMemory:   0,
+		},
+		{
+			name: "resources block present but requests unset",
+			resources: &acidv1.Resources{
+				ResourceRequests: acidv1.ResourceDescription{},
+			},
+			diffReplicas: 4,
+			wantCPU:      0,
+			wantMemory:   0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			pgResource := &postgresql{&acidv1.Postgresql{}}
+			pgResource.Spec.Resources = test.resources
+
+			saved := pgResource.getSavedResourcesRequests(test.diffReplicas)
+
+			assert.InDelta(t, test.wantCPU, saved.TotalCPU(), 0.0001)
+			assert.InDelta(t, test.wantMemory, saved.TotalMemory(), 1e5)
+		})
+	}
+}
+
+func TestPostgresql_Copy(t *testing.T) {
+	t.Parallel()
+
+	original := &postgresql{&acidv1.Postgresql{}}
+	original.Spec.NumberOfInstances = 5
+
+	copied, err := original.Copy()
+	require.NoError(t, err)
+
+	// Mutating the original must not affect the copy (deep copy).
+	original.Spec.NumberOfInstances = 0
+
+	rsw, ok := copied.(*replicaScaledWorkload)
+	require.True(t, ok)
+
+	copiedPg, ok := rsw.replicaScaledResource.(*postgresql)
+	require.True(t, ok)
+	assert.Equal(t, int32(5), copiedPg.Spec.NumberOfInstances)
+}
+
+func TestPostgresql_Compare(t *testing.T) {
+	t.Parallel()
+
+	original := &postgresql{&acidv1.Postgresql{}}
+	original.Spec.NumberOfInstances = 5
+
+	copied, err := original.Copy()
+	require.NoError(t, err)
+
+	rsw, ok := copied.(*replicaScaledWorkload)
+	require.True(t, ok)
+
+	copiedPg, ok := rsw.replicaScaledResource.(*postgresql)
+	require.True(t, ok)
+
+	err = copiedPg.setReplicas(0)
+	require.NoError(t, err)
+
+	patch, err := original.Compare(copied)
+	require.NoError(t, err)
+	assert.NotEmpty(t, patch, "expected a diff between differing instance counts")
+
+	// Comparing against a workload that is not a *postgresql must error.
+	wrongType := &replicaScaledWorkload{&deployment{&appsv1.Deployment{}}}
+	_, err = original.Compare(wrongType)
+
+	var expectErr *ExpectTypeGotTypeError
+	assert.ErrorAs(t, err, &expectErr)
+}
+
+func TestPostgresql_ScaleDownScaleUp(t *testing.T) {
+	t.Parallel()
+
+	pgResource := &acidv1.Postgresql{}
+	pgResource.Spec.NumberOfInstances = 5
+	pgResource.Spec.Resources = &acidv1.Resources{
+		ResourceRequests: acidv1.ResourceDescription{
+			CPU:    strPtr("100m"),
+			Memory: strPtr("64Mi"),
+		},
+	}
+
+	workload := &replicaScaledWorkload{&postgresql{pgResource}}
+
+	// Scale down to zero.
+	saved, updateNeeded, err := workload.ScaleDown(values.AbsoluteReplicas(0))
+	require.NoError(t, err)
+	assert.True(t, updateNeeded)
+
+	gotReplicas, err := workload.getReplicas()
+	require.NoError(t, err)
+	assert.Equal(t, values.AbsoluteReplicas(0), gotReplicas)
+
+	assert.InDelta(t, 0.5, saved.TotalCPU(), 0.0001)                     // 5 × 0.1 cores
+	assert.InDelta(t, float64(5*64*1024*1024), saved.TotalMemory(), 1e5) // 5 × 64Mi
+
+	// Original replicas were recorded.
+	original, err := getOriginalReplicas(workload)
+	require.NoError(t, err)
+	assert.Equal(t, values.AbsoluteReplicas(5), original)
+
+	// Scale back up restores the original instance count.
+	updateNeeded, err = workload.ScaleUp()
+	require.NoError(t, err)
+	assert.True(t, updateNeeded)
+
+	gotReplicas, err = workload.getReplicas()
+	require.NoError(t, err)
+	assert.Equal(t, values.AbsoluteReplicas(5), gotReplicas)
+
+	// The original-replicas annotation must be cleared after scaling up, so a second
+	// ScaleUp would be a no-op.
+	_, err = getOriginalReplicas(workload)
+
+	var unsetErr *OriginalReplicasUnsetError
+	assert.ErrorAs(t, err, &unsetErr)
+}
+
+func TestParsePostgresqlFromBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid postgresql is parsed and wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		raw := []byte(`{"metadata":{"name":"test-db","namespace":"default"},"spec":{"numberOfInstances":3}}`)
+
+		workload, err := parsePostgresqlFromBytes(raw)
+		require.NoError(t, err)
+
+		assert.Equal(t, "test-db", workload.GetName())
+		assert.Equal(t, "default", workload.GetNamespace())
+
+		replicas, err := workload.(*replicaScaledWorkload).getReplicas()
+		require.NoError(t, err)
+		assert.Equal(t, values.AbsoluteReplicas(3), replicas)
+	})
+
+	t.Run("invalid json returns an error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := parsePostgresqlFromBytes([]byte(`{not valid json`))
+		require.Error(t, err)
+	})
+}

--- a/internal/pkg/scalable/workload.go
+++ b/internal/pkg/scalable/workload.go
@@ -36,6 +36,7 @@ func GetWorkloads(resource, namespace string, clientsets *Clientsets, ctx contex
 		"stacks":                   getStacks,
 		"prometheuses":             getPrometheuses,
 		"autoscalingrunnersets":    getAutoscalingRunnerSets,
+		"postgresqls":              getPostgresqls,
 	}
 
 	resourceFunc, exists := resourceFuncMap[resource]
@@ -71,6 +72,7 @@ func ParseWorkloadFromRawObject(resource string, rawObject []byte) (Workload, er
 		"stack":                   parseStackFromBytes,
 		"prometheus":              parsePrometheusFromBytes,
 		"autoscalingrunnerset":    parseAutoscalingRunnerSetFromBytes,
+		"postgresql":              parsePostgresqlFromBytes,
 	}
 
 	parseFunc, exists := parseWorkloadFuncMap[resource]

--- a/website/content/docs/2 - downscaler/3 - Workload Types.mdx
+++ b/website/content/docs/2 - downscaler/3 - Workload Types.mdx
@@ -108,3 +108,10 @@ Scales by setting the replica count to the [downscale replicas](ref:docs-values#
 - resource: autoscalingrunnerset.v1alpha1.actions.github.com
 
 Scales by setting the minRunners count to the [downscale replicas](ref:docs-values#downscale-replicas).
+
+### Postgresqls
+
+- id: postgresqls
+- resource: postgresql.v1.acid.zalan.do
+
+Scales by setting the numberOfInstances count to the [downscale replicas](ref:docs-values#downscale-replicas).

--- a/website/src/components/Homepage/SupportedResources/SupportedResources.tsx
+++ b/website/src/components/Homepage/SupportedResources/SupportedResources.tsx
@@ -62,7 +62,7 @@ const SupportedResourceGroupList: SupportedResourceGroupProps[] = [
     SvgLight: ZalandoSVG.default,
     SvgDark: ZalandoSVG.default,
     href: "https://opensource.zalando.com/",
-    supportedResources: ["Stacks"],
+    supportedResources: ["Stacks", "Postgresqls"],
   },
   {
     title: "GitHub Actions",


### PR DESCRIPTION
## Motivation

Adds support for scaling Zalando postgres-operator `postgresql` resources (`acid.zalan.do/v1`), as discussed in #468.

Today there is no operator-native way to downscale a Zalando-managed Postgres with the downscaler. The only option is to include statefulsets, so the scanner patches `spec.replicas` to 0 on the operator-created sts. But `spec.numberOfInstances` on the postgresql CR - not the sts's replicas - is the operator's authoritative desired state, so the operator's sync loop detects the patched sts as drift (compareStatefulSetWith flags the replica mismatch) and re-applies its desired replica count on every reconcile. The scanner then patches it back to 0 on its next interval, and the two keep overwriting each other for the whole downtime window.

This change scales the postgresql CR's own `spec.numberOfInstances` instead - operator-native, so the operator treats "0 instances" as the desired state, reconciles the StatefulSet down itself, and stays quiet during downtime.

While validating the webhook path end-to-end on a real cluster, I found the chart's admission-controller (webhook) deployment was entirely non-functional under tight RBAC - the webhook pod couldn't start its cert rotation or watch its own resources. This PR also fixes those pre-existing chart bugs (see Changes), since they had to be fixed to test the webhook path for this feature.

## Changes

Feature - zalando postgresql support:
- New postgresqls scalable (internal/pkg/scalable/postgresqls.go): scales the Postgresql CR via `spec.numberOfInstances`, wrapped in the existing replicaScaledWorkload. Accessed through the controller-runtime client, importing only the postgres-operator API types package (github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1) - not its generated clientset - to avoid a k8s.io/client-go version conflict. Mirrors the autoscalingrunnersets scalable pattern.
- Registration (internal/pkg/scalable/workload.go): adds postgresqls to the resource map and postgresql to the admission-parse map.
- Scheme (internal/api/kubernetes/client.go): registers acidv1.AddToScheme on the controller-runtime scheme.
- Helm chart (deployments/chart/templates/_helpers.tpl, values.yaml): RBAC + webhook rules for postgresqls, plus the commented includedResources example.
- Dependency (go.mod, go.sum): adds github.com/zalando/postgres-operator (API types only; k8s.io/client-go unchanged).
- Tests (internal/pkg/scalable/postgresqls_test.go): set/get replicas (incl. the value-int32 no-unset case), saved-resource calculation (nil/partial/unparseable requests), Copy, Compare, scale-down/up round-trip, parsePostgresqlFromBytes.
- Docs (website/content/docs/2 - downscaler/3 - Workload Types.mdx, homepage SupportedResources.tsx).

Webhook chart fixes (pre-existing bugs found while testing the webhook path; each is its own commit):
- fix(chart): use webhook image tag for webhook deployment - the webhook Deployment built its image tag from .Values.image.tag (the main image) instead of .Values.webhookController.image.tag, which was defined but never consumed. Broke any setup pinning the webhook to a distinct tag/registry.
- fix(chart): allow webhook SA to create its TLS secret - the webhook SA's create on secrets was scoped with resourceNames; Kubernetes ignores resourceNames for create, so cert rotation got secrets is forbidden. Split into an unrestricted create + the name-scoped read/modify verbs.
- fix(chart): allow webhook SA to list/watch mutatingwebhookconfigurations - the reflector must list the collection before watching, but list was missing and the rule was resourceNames-scoped (which can't apply to list). Added an unrestricted list/watch rule.
- fix(chart): allow webhook SA to list/watch secrets - same resourceNames/list issue for the secret reflector. Moved list/watch to the unrestricted rule.

## Tests Done

- go test ./... - all green, including the new postgresqls unit tests.
- golangci-lint run - clean (0 issues).
- helm lint + helm template - chart renders correctly with postgresqls in includedResources and with the webhook enabled (RBAC, webhook rules, and both deployment images render as expected).
- End-to-end against a live zalando postgres-operator dev cluster:
  - Scanner path: downscale patched numberOfInstances → 0, the operator scaled the StatefulSet to 0 and terminated pods, with no could not connect log noise during the downtime window. Upscale restored the original instance count from the downscaler/original-replicas annotation.
  - Confirmed the operator accepts numberOfInstances: 0 (no enforced minimum on the default config).
  - Webhook path: after the chart RBAC fixes above, the webhook pod started cleanly (cert rotation + CA injection working); a CREATE/UPDATE of a Postgresql was intercepted and numberOfInstances rewritten to the downscale target inline, with no conflict against the operator's own webhooks.