### PR TITLE
fix: don't skip ScaledObjects with undefined current replicas

### DIFF
--- a/internal/pkg/scalable/replicaScaledWorkloads.go
+++ b/internal/pkg/scalable/replicaScaledWorkloads.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/caas-team/gokubedownscaler/internal/pkg/metrics"
+	"github.com/caas-team/gokubedownscaler/internal/pkg/util"
 	"github.com/caas-team/gokubedownscaler/internal/pkg/values"
 	"github.com/wI2L/jsondiff"
 )
@@ -82,7 +83,10 @@ func (r *replicaScaledWorkload) ScaleDown(downscaleReplicas values.Replicas) (*m
 		return savedResources, false, fmt.Errorf("failed to convert current replicas to int32: %w", err)
 	}
 
-	if currentReplicasInt32 <= downscaleReplicasInt32 {
+	// util.Undefined (-1) is a sentinel for "no current replicas set" (e.g. a ScaledObject without a
+	// paused-replicas annotation). It must not be treated as already being at or below the downtime target,
+	// otherwise such workloads would never be scaled down.
+	if currentReplicasInt32 != util.Undefined && currentReplicasInt32 <= downscaleReplicasInt32 {
 		var originalReplicasInt32 int32
 		var isOriginalReplicasSet bool
 

--- a/internal/pkg/scalable/replicaScaledWorkloads_test.go
+++ b/internal/pkg/scalable/replicaScaledWorkloads_test.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/caas-team/gokubedownscaler/internal/pkg/util"
 	"github.com/caas-team/gokubedownscaler/internal/pkg/values"
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -225,4 +227,51 @@ func TestReplicaScaledWorkload_ScaleDown(t *testing.T) {
 			assert.InDelta(t, test.wantSavedMemory, savedResources.TotalMemory(), 1e5) // Memory tolerance
 		})
 	}
+}
+
+// TestReplicaScaledWorkload_ScaleDown_ScaledObjectUndefinedReplicas ensures that a ScaledObject without a
+// paused-replicas annotation (getReplicas reports the util.Undefined sentinel) is still scaled down, instead
+// of being skipped as if it were already at or below the downtime target. It also covers the scale-up
+// round-trip: the undefined sentinel must be recorded as the original replicas and restored cleanly.
+func TestReplicaScaledWorkload_ScaleDown_ScaledObjectUndefinedReplicas(t *testing.T) {
+	t.Parallel()
+
+	workload := &replicaScaledWorkload{&scaledObject{&kedav1alpha1.ScaledObject{}}}
+
+	// no paused-replicas annotation means the current replicas are undefined
+	current, err := workload.getReplicas()
+	require.NoError(t, err)
+	currentInt32, err := current.AsInt32()
+	require.NoError(t, err)
+	require.Equal(t, int32(util.Undefined), currentInt32)
+
+	// scale down: the workload must be paused and the undefined sentinel recorded as the original replicas
+	_, updateNeeded, err := workload.ScaleDown(values.AbsoluteReplicas(1))
+	require.NoError(t, err)
+	assert.True(t, updateNeeded, "scaled object with undefined replicas should be scaled down")
+
+	gotReplicas, err := workload.getReplicas()
+	require.NoError(t, err)
+	assert.Equal(t, values.AbsoluteReplicas(1), gotReplicas)
+
+	gotOriginal, err := getOriginalReplicas(workload)
+	require.NoError(t, err)
+	assert.Equal(t, values.AbsoluteReplicas(util.Undefined), gotOriginal,
+		"the undefined sentinel must be recorded as the original replicas")
+
+	// scale up: the original (undefined) replicas must be restored, removing the paused-replicas annotation
+	updateNeeded, err = workload.ScaleUp()
+	require.NoError(t, err)
+	assert.True(t, updateNeeded, "scaled object should be scaled back up")
+
+	restored, err := workload.getReplicas()
+	require.NoError(t, err)
+	restoredInt32, err := restored.AsInt32()
+	require.NoError(t, err)
+	assert.Equal(t, int32(util.Undefined), restoredInt32,
+		"scale up must restore the undefined state (no paused-replicas annotation)")
+
+	_, hasOriginal := getOriginalReplicas(workload)
+	var unsetErr *OriginalReplicasUnsetError
+	assert.ErrorAs(t, hasOriginal, &unsetErr, "original-replicas annotation must be removed after scale up")
 }

--- a/internal/pkg/scalable/replicaScaledWorkloads_test.go
+++ b/internal/pkg/scalable/replicaScaledWorkloads_test.go
@@ -236,42 +236,67 @@ func TestReplicaScaledWorkload_ScaleDown(t *testing.T) {
 func TestReplicaScaledWorkload_ScaleDown_ScaledObjectUndefinedReplicas(t *testing.T) {
 	t.Parallel()
 
-	workload := &replicaScaledWorkload{&scaledObject{&kedav1alpha1.ScaledObject{}}}
+	tests := []struct {
+		name             string
+		downtimeReplicas values.Replicas
+		wantReplicas     values.Replicas
+	}{
+		{
+			name:             "downtime replicas 1",
+			downtimeReplicas: values.AbsoluteReplicas(1),
+			wantReplicas:     values.AbsoluteReplicas(1),
+		},
+		{
+			// the undefined sentinel (-1) must not be treated as already at/below the target,
+			// regardless of the configured downtime-replicas
+			name:             "downtime replicas 0",
+			downtimeReplicas: values.AbsoluteReplicas(0),
+			wantReplicas:     values.AbsoluteReplicas(0),
+		},
+	}
 
-	// no paused-replicas annotation means the current replicas are undefined
-	current, err := workload.getReplicas()
-	require.NoError(t, err)
-	currentInt32, err := current.AsInt32()
-	require.NoError(t, err)
-	require.Equal(t, int32(util.Undefined), currentInt32)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-	// scale down: the workload must be paused and the undefined sentinel recorded as the original replicas
-	_, updateNeeded, err := workload.ScaleDown(values.AbsoluteReplicas(1))
-	require.NoError(t, err)
-	assert.True(t, updateNeeded, "scaled object with undefined replicas should be scaled down")
+			workload := &replicaScaledWorkload{&scaledObject{&kedav1alpha1.ScaledObject{}}}
 
-	gotReplicas, err := workload.getReplicas()
-	require.NoError(t, err)
-	assert.Equal(t, values.AbsoluteReplicas(1), gotReplicas)
+			// no paused-replicas annotation means the current replicas are undefined
+			current, err := workload.getReplicas()
+			require.NoError(t, err)
+			currentInt32, err := current.AsInt32()
+			require.NoError(t, err)
+			require.Equal(t, int32(util.Undefined), currentInt32)
 
-	gotOriginal, err := getOriginalReplicas(workload)
-	require.NoError(t, err)
-	assert.Equal(t, values.AbsoluteReplicas(util.Undefined), gotOriginal,
-		"the undefined sentinel must be recorded as the original replicas")
+			// scale down: the workload must be paused and the undefined sentinel recorded as the original replicas
+			_, updateNeeded, err := workload.ScaleDown(test.downtimeReplicas)
+			require.NoError(t, err)
+			assert.True(t, updateNeeded, "scaled object with undefined replicas should be scaled down")
 
-	// scale up: the original (undefined) replicas must be restored, removing the paused-replicas annotation
-	updateNeeded, err = workload.ScaleUp()
-	require.NoError(t, err)
-	assert.True(t, updateNeeded, "scaled object should be scaled back up")
+			gotReplicas, err := workload.getReplicas()
+			require.NoError(t, err)
+			assert.Equal(t, test.wantReplicas, gotReplicas)
 
-	restored, err := workload.getReplicas()
-	require.NoError(t, err)
-	restoredInt32, err := restored.AsInt32()
-	require.NoError(t, err)
-	assert.Equal(t, int32(util.Undefined), restoredInt32,
-		"scale up must restore the undefined state (no paused-replicas annotation)")
+			gotOriginal, err := getOriginalReplicas(workload)
+			require.NoError(t, err)
+			assert.Equal(t, values.AbsoluteReplicas(util.Undefined), gotOriginal,
+				"the undefined sentinel must be recorded as the original replicas")
 
-	_, hasOriginal := getOriginalReplicas(workload)
-	var unsetErr *OriginalReplicasUnsetError
-	assert.ErrorAs(t, hasOriginal, &unsetErr, "original-replicas annotation must be removed after scale up")
+			// scale up: the original (undefined) replicas must be restored, removing the paused-replicas annotation
+			updateNeeded, err = workload.ScaleUp()
+			require.NoError(t, err)
+			assert.True(t, updateNeeded, "scaled object should be scaled back up")
+
+			restored, err := workload.getReplicas()
+			require.NoError(t, err)
+			restoredInt32, err := restored.AsInt32()
+			require.NoError(t, err)
+			assert.Equal(t, int32(util.Undefined), restoredInt32,
+				"scale up must restore the undefined state (no paused-replicas annotation)")
+
+			_, hasOriginal := getOriginalReplicas(workload)
+			var unsetErr *OriginalReplicasUnsetError
+			assert.ErrorAs(t, hasOriginal, &unsetErr, "original-replicas annotation must be removed after scale up")
+		})
+	}
 }


### PR DESCRIPTION
## Description

Fixes #475.

#456 changed the scale-down guard in `replicaScaledWorkload.ScaleDown` from `==` to `<=`, so a workload already **below** the downtime target is skipped:

```go
if currentReplicasInt32 <= downscaleReplicasInt32 {
    // treat as already at/below target, skip
}
```

This also matches the `util.Undefined` (`-1`) sentinel that a KEDA `ScaledObject` reports from `getReplicas()` when it has no `autoscaling.keda.sh/paused-replicas` annotation (`scaledobjects.go`). Since `-1 <=` any non-negative `downtime-replicas`, **every not-yet-paused ScaledObject is skipped and never downscaled** — confirmed on a 1.3.4 cluster where 0 of 199 ScaledObjects were paused during an active downtime window.

## Change

Exclude the undefined sentinel from the skip check:

```go
if currentReplicasInt32 != util.Undefined && currentReplicasInt32 <= downscaleReplicasInt32 {
```

A workload whose current replicas are undefined (`-1`) now proceeds to be scaled down, the sentinel is recorded as `downscaler/original-replicas`, and scale-up restores it (deleting the paused-replicas annotation) via the existing `util.Undefined` handling in `setReplicas`/`ReplicasValue.Set`.

Only `scaledObject.getReplicas()` can return `util.Undefined`; every other workload type returns a real replica count or errors, so their behavior is unchanged. The intent of #456 (skip workloads genuinely below the downtime target) is preserved.

## Testing

Added `TestReplicaScaledWorkload_ScaleDown_ScaledObjectUndefinedReplicas`, covering the full scale-down → scale-up round-trip for a ScaledObject with no paused-replicas annotation. `go test ./internal/pkg/scalable/` passes.
