### PR TITLE
Feat/Ignore Stale Exclude-Until Annotations When Setting Scopes

### DIFF
--- a/internal/pkg/values/scope.go
+++ b/internal/pkg/values/scope.go
@@ -325,7 +325,7 @@ func (s Scopes) GetExcluded(scopes Scopes) bool {
 		}
 
 		if !scope.ExcludeUntil.After(time.Now()) {
-			// ExcludeUntil is expired, continue checking the next scope
+			// ExcludeUntil is expired, continue checking the next scop
 			continue
 		}
 

--- a/internal/pkg/values/scope.go
+++ b/internal/pkg/values/scope.go
@@ -324,11 +324,12 @@ func (s Scopes) GetExcluded(scopes Scopes) bool {
 			continue
 		}
 
-		if scope.ExcludeUntil.After(time.Now()) {
-			return true
+		if !scope.ExcludeUntil.After(time.Now()) {
+			// ExcludeUntil is expired, continue checking the next scope
+			continue
 		}
 
-		// ExcludeUntil is expired, continue checking the next scope
+		return true
 	}
 
 	return false

--- a/internal/pkg/values/scope.go
+++ b/internal/pkg/values/scope.go
@@ -328,7 +328,7 @@ func (s Scopes) GetExcluded(scopes Scopes) bool {
 			return true
 		}
 
-		break
+		// ExcludeUntil is expired, continue checking the next scope
 	}
 
 	return false

--- a/internal/pkg/values/scope.go
+++ b/internal/pkg/values/scope.go
@@ -325,7 +325,7 @@ func (s Scopes) GetExcluded(scopes Scopes) bool {
 		}
 
 		if !scope.ExcludeUntil.After(time.Now()) {
-			// ExcludeUntil is expired, continue checking the next scop
+			// ExcludeUntil is expired, continue checking the next scope
 			continue
 		}
 

--- a/internal/pkg/values/scopeParser.go
+++ b/internal/pkg/values/scopeParser.go
@@ -207,7 +207,9 @@ func (s *Scope) GetScopeFromAnnotations( //nolint: funlen,gocognit,cyclop,gocycl
 			return err
 		}
 
-		s.ExcludeUntil = &excludeUntil
+		if excludeUntil.After(time.Now()) {
+			s.ExcludeUntil = &excludeUntil
+		}
 	}
 
 	if forceUptime, ok := annotations[annotationForceUptime]; ok {

--- a/internal/pkg/values/scopeParser.go
+++ b/internal/pkg/values/scopeParser.go
@@ -207,9 +207,7 @@ func (s *Scope) GetScopeFromAnnotations( //nolint: funlen,gocognit,cyclop,gocycl
 			return err
 		}
 
-		if excludeUntil.After(time.Now()) {
-			s.ExcludeUntil = &excludeUntil
-		}
+		s.ExcludeUntil = &excludeUntil
 	}
 
 	if forceUptime, ok := annotations[annotationForceUptime]; ok {

--- a/internal/pkg/values/scope_test.go
+++ b/internal/pkg/values/scope_test.go
@@ -789,6 +789,17 @@ func TestScopes_GetExcluded(t *testing.T) {
 			},
 			wantExcluded: false,
 		},
+		{
+			name: "workload past exclude-until ignored, namespace future exclude-until applies",
+			scopes: Scopes{
+				&Scope{ExcludeUntil: nil},
+				&Scope{ExcludeUntil: &timeUntilTrue},
+				&Scope{},
+				&Scope{},
+				&Scope{},
+			},
+			wantExcluded: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/pkg/values/scope_test.go
+++ b/internal/pkg/values/scope_test.go
@@ -792,13 +792,24 @@ func TestScopes_GetExcluded(t *testing.T) {
 		{
 			name: "workload past exclude-until ignored, namespace future exclude-until applies",
 			scopes: Scopes{
-				&Scope{ExcludeUntil: nil},
+				&Scope{ExcludeUntil: &timeUntilFalse},
 				&Scope{ExcludeUntil: &timeUntilTrue},
 				&Scope{},
 				&Scope{},
 				&Scope{},
 			},
 			wantExcluded: true,
+		},
+		{
+			name: "exclude until past, not excluded",
+			scopes: Scopes{
+				&Scope{ExcludeUntil: &timeUntilFalse},
+				&Scope{},
+				&Scope{},
+				&Scope{},
+				&Scope{},
+			},
+			wantExcluded: false,
 		},
 	}
 


### PR DESCRIPTION
## Motivation

As explained in #482 when the downscaler encounters a `downscaler/exclude-until` annotation whose timestamp is in the past, it still sets its value in the scope. This could lead to potential unwanted behaviors

## Changes

- Refactored `GetExcluded` function in `scopes.go`; `downscaler/exclude-until` annotations won't be considered anymore if the annotations is in the past
- Added unit tests dedicated to this case

## Tests Done

- Unit Tests
