### PR TITLE
Fix/Migration To Actions/Checkout V7

### DIFF
--- a/.github/workflows/check_for_release.yaml
+++ b/.github/workflows/check_for_release.yaml
@@ -18,13 +18,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: ${{ github.base_ref }}
           fetch-depth: 0
+
+      - name: Fetch PR head
+        run: |
+          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
 
       - name: Check for appVersion changes
         run: |
           echo "Checking for appVersion changes..."
-          if git diff origin/${{ github.base_ref }} -- deployments/chart/Chart.yaml | grep -qe "^[+-]appVersion: "; then
+          if git diff HEAD pr-head -- deployments/chart/Chart.yaml | grep -qe "^[+-]appVersion: "; then
             app_version_change=$(echo "version changed")
             echo "app_version_change=$app_version_change" >> $GITHUB_ENV
           else
@@ -35,7 +39,7 @@ jobs:
       - name: Validate semantic versioning
         if: ${{ env.app_version_change == 'version changed' }}
         run: |
-          app_version=$(yq e '.appVersion' ./deployments/chart/Chart.yaml)
+          app_version=$(git show pr-head:deployments/chart/Chart.yaml | yq e '.appVersion' -)
           if ! echo "$app_version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::appVersion '$app_version' is not valid semantic versioning. Expected MAJOR.MINOR.PATCH (e.g. 1.3.0)"
             exit 1
@@ -81,13 +85,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: ${{ github.base_ref }}
           fetch-depth: 0
+
+      - name: Fetch PR head
+        run: |
+          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
 
       - name: Extract appVersion
         id: extract_appversion
         run: |
-          appversion=$(yq e '.appVersion' ./deployments/chart/Chart.yaml | tr -d '\n' | tr -d '\r')
+          if git diff HEAD pr-head -- deployments/chart/Chart.yaml | grep -qe "^[+-]appVersion: "; then
+            appversion=$(git show pr-head:deployments/chart/Chart.yaml | yq e '.appVersion' - | tr -d '\n' | tr -d '\r')
+          else
+            appversion=$(yq e '.appVersion' ./deployments/chart/Chart.yaml | tr -d '\n' | tr -d '\r')
+          fi
           echo "appversion=$appversion" >> $GITHUB_ENV
 
       - name: Post warning comment

--- a/.github/workflows/check_for_release.yaml
+++ b/.github/workflows/check_for_release.yaml
@@ -73,7 +73,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Remove approval label
-        continue-on-error: true
         run: |
           gh pr edit "${{ github.event.pull_request.number }}" --remove-label "needs approval"
         env:

--- a/.github/workflows/check_for_release.yaml
+++ b/.github/workflows/check_for_release.yaml
@@ -55,6 +55,7 @@ jobs:
           echo "appVersion '$app_version' correctly follows semantic versioning"
 
       - name: Remove new version label
+        continue-on-error: true
         if: ${{ env.app_version_change == 'No appVersion changes detected.' }}
         run: |
           echo "No appVersion changes detected. Removing new version label"

--- a/.github/workflows/check_for_release.yaml
+++ b/.github/workflows/check_for_release.yaml
@@ -18,12 +18,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
       - name: Fetch PR head
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
+          git fetch --no-tags origin "refs/pull/${PR_NUMBER}/head"
+          git branch --force pr-head FETCH_HEAD
+          test "$(git rev-parse pr-head)" = "$PR_HEAD_SHA" || {
+            echo "❌ Error: The pull request changed while this workflow was running."
+            exit 1
+          }
 
       - name: Check for appVersion changes
         run: |
@@ -54,22 +62,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fail if changes occured
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'new release') }}
+      - name: Fail if changes occurred
+        if: ${{ env.app_version_change == 'version changed' && !contains(github.event.pull_request.labels.*.name, 'new release') }}
         run: |
-          if [ "${{ env.app_version_change }}" == "version changed" ]; then
-            gh pr edit ${{ github.event.pull_request.number }} --add-label "needs approval"
-            echo "Version changed, exiting..."
-            exit 1
-          else
-            echo "No appVersion changes detected."
-          fi
+          gh pr edit "${{ github.event.pull_request.number }}" --add-label "needs approval"
+          echo "Version changed, exiting..."
+          exit 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Remove approval label
+        continue-on-error: true
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label "needs approval"
+          gh pr edit "${{ github.event.pull_request.number }}" --remove-label "needs approval"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -77,20 +82,29 @@ jobs:
     name: Post Message To Warn Of New Release
     runs-on: ubuntu-latest
     needs: check_for_release
-    if: ${{ failure() && !contains(github.event.pull_request.labels.*.name, 'needs approval') && github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
+    if: ${{ needs.check_for_release.result == 'failure' && !contains(github.event.pull_request.labels.*.name, 'needs approval') && github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
     permissions:
+      contents: read
       pull-requests: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
       - name: Fetch PR head
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
+          git fetch --no-tags origin "refs/pull/${PR_NUMBER}/head"
+          git branch --force pr-head FETCH_HEAD
+          test "$(git rev-parse pr-head)" = "$PR_HEAD_SHA" || {
+            echo "::error::The pull request changed while this workflow was running."
+            exit 1
+          }
 
       - name: Extract appVersion
         id: extract_appversion

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: go-deadcode
         args: ["--exclude-regex", "/website/node_modules/"]
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.9.5
+    rev: v3.9.6
     hooks:
       - id: prettier
         files: \.(md|mdx)$


### PR DESCRIPTION
## Motivation

`actions/checkout@v7` comes with some breaking changes for PRs from forked repos. In V7, by default, `pull_request_target` doesn't checkout code from forked repos without specifying the `allow-unsafe-pr-checkout` flag set to true

> Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

More here: https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target

## Changes

- Tried to refactor the action using a more secure approach
