### PR TITLE
Fix/Migrating ESLint For Pre-Commit 4.6.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,5 +55,5 @@ repos:
       - id: eslint
         name: Run ESLint
         entry: npx eslint --fix --config=website/eslint.config.mjs "website/**/*.{js,jsx,ts,tsx,cts,cjs,mdx}"
-        language: node
+        language: system
         files: website/.*\.(js|jsx|ts|tsx|cts|cjs|mdx)$


### PR DESCRIPTION
## Motivation

Some breaking changes were introduced with pre-commit 4.6.1 that is affecting the eslint hook

## Changes

- Set `language: system` in the `eslint` hook as mentioned here (jupyterlab/jupyterlab#19193)

## Tests Done

- PR on personal fork -> https://github.com/samuel-esp/GoKubeDownscaler/pull/4
