### PR TITLE
Fix/Default Timezone Not Correctly Set

### DIFF
--- a/internal/pkg/util/timezoneValue.go
+++ b/internal/pkg/util/timezoneValue.go
@@ -6,15 +6,15 @@ import (
 )
 
 type TimezoneValue struct {
-	Value **time.Location
+	Value *time.Location
 }
 
 func (t *TimezoneValue) String() string {
-	if t == nil || t.Value == nil || *t.Value == nil {
+	if t == nil || t.Value == nil {
 		return ""
 	}
 
-	return (*t.Value).String()
+	return t.Value.String()
 }
 
 func (t *TimezoneValue) Set(value string) error {
@@ -27,11 +27,7 @@ func (t *TimezoneValue) Set(value string) error {
 		return fmt.Errorf("invalid timezone %q: %w", value, err)
 	}
 
-	if t.Value == nil {
-		return NewNilTimezoneError("timezone value is nil")
-	}
-
-	*t.Value = loc
+	t.Value = loc
 
 	return nil
 }

--- a/internal/pkg/util/timezoneValue.go
+++ b/internal/pkg/util/timezoneValue.go
@@ -6,15 +6,15 @@ import (
 )
 
 type TimezoneValue struct {
-	Value *time.Location
+	Value **time.Location
 }
 
 func (t *TimezoneValue) String() string {
-	if t == nil || t.Value == nil {
+	if t == nil || t.Value == nil || *t.Value == nil {
 		return ""
 	}
 
-	return t.Value.String()
+	return (*t.Value).String()
 }
 
 func (t *TimezoneValue) Set(value string) error {
@@ -27,7 +27,11 @@ func (t *TimezoneValue) Set(value string) error {
 		return fmt.Errorf("invalid timezone %q: %w", value, err)
 	}
 
-	t.Value = loc
+	if t.Value == nil {
+		return NewNilTimezoneError("timezone value is nil")
+	}
+
+	*t.Value = loc
 
 	return nil
 }

--- a/internal/pkg/values/dayTime.go
+++ b/internal/pkg/values/dayTime.go
@@ -52,7 +52,7 @@ type dayTime int
 
 func (d dayTime) String() string {
 	minute := d % Hour
-	hour := d - minute
+	hour := d / Hour
 
-	return fmt.Sprintf("%d:%d", hour, minute)
+	return fmt.Sprintf("%02d:%02d", hour, minute)
 }

--- a/internal/pkg/values/dayTime_test.go
+++ b/internal/pkg/values/dayTime_test.go
@@ -1,0 +1,28 @@
+package values
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDayTimeString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   dayTime
+		want string
+	}{
+		{name: "exact hour", in: 8 * Hour, want: "08:00"},
+		{name: "hour and minute", in: 13*Hour + 5*Minute, want: "13:05"},
+		{name: "end of day", in: 23*Hour + 59*Minute, want: "23:59"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.in.String())
+		})
+	}
+}

--- a/internal/pkg/values/scope.go
+++ b/internal/pkg/values/scope.go
@@ -213,6 +213,10 @@ func (s Scopes) GetDefaultTimeSpan() *time.Location {
 
 func (s Scopes) GetDefaultWeekdayFrom() *time.Weekday {
 	for _, scope := range s {
+		if scope.DefaultWeekFrame == nil {
+			continue
+		}
+
 		weekdayFrom := scope.DefaultWeekFrame.WeekdayFrom
 		if weekdayFrom == nil {
 			continue
@@ -226,6 +230,10 @@ func (s Scopes) GetDefaultWeekdayFrom() *time.Weekday {
 
 func (s Scopes) GetDefaultWeekdayTo() *time.Weekday {
 	for _, scope := range s {
+		if scope.DefaultWeekFrame == nil {
+			continue
+		}
+
 		weekdayTo := scope.DefaultWeekFrame.WeekdayTo
 		if weekdayTo == nil {
 			continue

--- a/internal/pkg/values/scopeParser.go
+++ b/internal/pkg/values/scopeParser.go
@@ -120,7 +120,7 @@ func (s *Scope) GetScopeFromEnv() error {
 		return fmt.Errorf("error while getting %q environment variable: %w", envDowntime, err)
 	}
 
-	if err = util.GetEnvValue(envTimezone, &util.TimezoneValue{Value: s.DefaultTimezone}); err != nil {
+	if err = util.GetEnvValue(envTimezone, &util.TimezoneValue{Value: &s.DefaultTimezone}); err != nil {
 		return fmt.Errorf("error while getting %q environment variable: %w", envTimezone, err)
 	}
 

--- a/internal/pkg/values/scopeParser.go
+++ b/internal/pkg/values/scopeParser.go
@@ -120,9 +120,12 @@ func (s *Scope) GetScopeFromEnv() error {
 		return fmt.Errorf("error while getting %q environment variable: %w", envDowntime, err)
 	}
 
-	if err = util.GetEnvValue(envTimezone, &util.TimezoneValue{Value: &s.DefaultTimezone}); err != nil {
+	timezoneValue := &util.TimezoneValue{}
+	if err = util.GetEnvValue(envTimezone, timezoneValue); err != nil {
 		return fmt.Errorf("error while getting %q environment variable: %w", envTimezone, err)
 	}
+
+	s.DefaultTimezone = timezoneValue.Value
 
 	if err = util.GetEnvValue(envWeekFrame, &util.WeekFrameValue{Value: &s.DefaultWeekFrame}); err != nil {
 		return fmt.Errorf("error while getting %q environment variable: %w", envWeekFrame, err)

--- a/internal/pkg/values/scopeParser_test.go
+++ b/internal/pkg/values/scopeParser_test.go
@@ -1,0 +1,204 @@
+package values
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func clearScopeEnvVars(t *testing.T) {
+	t.Helper()
+
+	keys := []string{
+		envUpscalePeriod,
+		envUptime,
+		envDownscalePeriod,
+		envDowntime,
+		envTimezone,
+		envWeekFrame,
+	}
+
+	for _, key := range keys {
+		oldValue, existed := os.LookupEnv(key)
+		require.NoError(t, os.Unsetenv(key))
+
+		if existed {
+			t.Setenv(key, oldValue)
+			continue
+		}
+
+		t.Cleanup(func() { require.NoError(t, os.Unsetenv(key)) })
+	}
+}
+
+func TestScopeGetScopeFromEnv_ParsesDefaultTimezone(t *testing.T) {
+	tests := []struct {
+		name            string
+		timezone        string
+		wantNil         bool
+		wantErr         bool
+		wantTimezoneStr string
+	}{
+		{
+			name:            "valid timezone parsed",
+			timezone:        "America/Bogota",
+			wantTimezoneStr: "America/Bogota",
+		},
+		{
+			name:     "invalid timezone returns error",
+			timezone: "Not/ATimezone",
+			wantErr:  true,
+		},
+		{
+			name:     "empty timezone leaves DefaultTimezone nil",
+			timezone: "",
+			wantNil:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearScopeEnvVars(t)
+
+			if test.timezone != "" {
+				t.Setenv(envTimezone, test.timezone)
+			}
+
+			scope := NewScope()
+			err := scope.GetScopeFromEnv()
+
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if test.wantNil {
+				require.Nil(t, scope.DefaultTimezone)
+				return
+			}
+
+			require.NotNil(t, scope.DefaultTimezone)
+			require.Equal(t, test.wantTimezoneStr, scope.DefaultTimezone.String())
+		})
+	}
+}
+
+func TestScopeGetScopeFromEnv_DefaultTimezoneAppliesToDowntimeWithoutTimezone(t *testing.T) {
+	tests := []struct {
+		name     string
+		timezone string
+		downtime string
+		wantErr  bool
+	}{
+		{
+			name:     "DEFAULT_TIMEZONE applies to timezone-less downtime",
+			timezone: "America/Bogota",
+			downtime: "Thu-Fri 12:55-13:00",
+		},
+		{
+			name:     "downtime without timezone and without DEFAULT_TIMEZONE fails",
+			downtime: "Thu-Fri 12:55-13:00",
+			wantErr:  true,
+		},
+		{
+			name:     "downtime with inline timezone ignores DEFAULT_TIMEZONE",
+			timezone: "America/Bogota",
+			downtime: "Thu-Fri 12:55-13:00 Europe/Berlin",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearScopeEnvVars(t)
+
+			if test.timezone != "" {
+				t.Setenv(envTimezone, test.timezone)
+			}
+
+			t.Setenv(envDowntime, test.downtime)
+
+			scopeEnv := NewScope()
+			err := scopeEnv.GetScopeFromEnv()
+			require.NoError(t, err)
+
+			scopes := Scopes{
+				NewScope(),
+				NewScope(),
+				NewScope(),
+				scopeEnv,
+				GetDefaultScope(),
+			}
+
+			_, err = scopeEnv.DownTime.inTimeSpans(scopes)
+
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestScopeGetScopeFromEnv_DefaultWeekFrameAppliesToDowntimeWithoutWeekdays(t *testing.T) {
+	tests := []struct {
+		name      string
+		weekframe string
+		downtime  string
+		wantErr   bool
+	}{
+		{
+			name:      "DEFAULT_WEEKFRAME applies to weekday-less downtime",
+			weekframe: "Mon-Fri",
+			downtime:  "12:55-13:00",
+		},
+		{
+			name:     "downtime without weekdays and without DEFAULT_WEEKFRAME fails",
+			downtime: "12:55-13:00",
+			wantErr:  true,
+		},
+		{
+			name:      "downtime with inline weekdays ignores DEFAULT_WEEKFRAME",
+			weekframe: "Mon-Fri",
+			downtime:  "Thu-Fri 12:55-13:00",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearScopeEnvVars(t)
+
+			if test.weekframe != "" {
+				t.Setenv(envWeekFrame, test.weekframe)
+			}
+
+			// The relative timespan parser requires a timezone to be present
+			t.Setenv(envTimezone, "UTC")
+
+			t.Setenv(envDowntime, test.downtime)
+
+			scopeEnv := NewScope()
+			err := scopeEnv.GetScopeFromEnv()
+			require.NoError(t, err)
+
+			scopes := Scopes{
+				NewScope(),
+				NewScope(),
+				NewScope(),
+				scopeEnv,
+				GetDefaultScope(),
+			}
+
+			_, err = scopeEnv.DownTime.inTimeSpans(scopes)
+
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Due to an oversight on my side, I had incorrectly implemented `timezoneValue.go`: without using the double pointer the location can never be customized as the user wanted. Closes #502 

## Changes

- Refactored `scopeParser.go`
- Refactored `timezoneValue.go`
- Added `scopeParser_test.go` to test both `DEFAULT_TIMEZONE` and `DEFAULT_WEEKFRAME`

## Tests Done

- Implemented dedicated test class for `scopeParser_test.go`
