### PR TITLE
Fix/Consider OwnerReference Only For Scalable Resources

### DIFF
--- a/internal/pkg/scalable/autoscalingrunnersets.go
+++ b/internal/pkg/scalable/autoscalingrunnersets.go
@@ -24,7 +24,7 @@ func getAutoscalingRunnerSets(namespace string, clientsets *Clientsets, ctx cont
 
 	results := make([]Workload, 0, len(runnerSets.Items))
 	for i := range runnerSets.Items {
-		setGroupVersionKindIfEmpty(&runnerSets.Items[i], actionsv1alpha1.GroupVersion.WithKind("AutoscalingRunnerSet"))
+		setGroupVersionKindIfEmpty(&runnerSets.Items[i], actionsv1alpha1.GroupVersion.WithKind(autoscalingRunnerSetKind))
 		results = append(results, &replicaScaledWorkload{&autoscalingRunnerSet{&runnerSets.Items[i]}})
 	}
 
@@ -52,7 +52,7 @@ func (a *autoscalingRunnerSet) Reget(clientsets *Clientsets, ctx context.Context
 		return fmt.Errorf("failed to get autoscalingrunnerset: %w", err)
 	}
 
-	setGroupVersionKindIfEmpty(a.AutoscalingRunnerSet, actionsv1alpha1.GroupVersion.WithKind("AutoscalingRunnerSet"))
+	setGroupVersionKindIfEmpty(a.AutoscalingRunnerSet, actionsv1alpha1.GroupVersion.WithKind(autoscalingRunnerSetKind))
 
 	return nil
 }

--- a/internal/pkg/scalable/cronjobs.go
+++ b/internal/pkg/scalable/cronjobs.go
@@ -25,7 +25,7 @@ func getCronJobs(namespace string, clientsets *Clientsets, ctx context.Context) 
 
 	results := make([]Workload, 0, len(cronjobs.Items))
 	for i := range cronjobs.Items {
-		setGroupVersionKindIfEmpty(&cronjobs.Items[i], batch.SchemeGroupVersion.WithKind("CronJob"))
+		setGroupVersionKindIfEmpty(&cronjobs.Items[i], batch.SchemeGroupVersion.WithKind(cronJobKind))
 		results = append(results, &suspendScaledWorkload{&cronJob{&cronjobs.Items[i]}})
 	}
 
@@ -69,7 +69,7 @@ func (c *cronJob) GetChildren(ctx context.Context, clientsets *Clientsets) ([]Wo
 				return
 			}
 
-			setGroupVersionKindIfEmpty(singleJob, batch.SchemeGroupVersion.WithKind("Job"))
+			setGroupVersionKindIfEmpty(singleJob, batch.SchemeGroupVersion.WithKind(jobKind))
 
 			mutex.Lock()
 
@@ -103,7 +103,7 @@ func (c *cronJob) Reget(clientsets *Clientsets, ctx context.Context) error {
 		return fmt.Errorf("failed to get cronjob: %w", err)
 	}
 
-	setGroupVersionKindIfEmpty(c.CronJob, batch.SchemeGroupVersion.WithKind("CronJob"))
+	setGroupVersionKindIfEmpty(c.CronJob, batch.SchemeGroupVersion.WithKind(cronJobKind))
 
 	return nil
 }

--- a/internal/pkg/scalable/daemonsets.go
+++ b/internal/pkg/scalable/daemonsets.go
@@ -29,7 +29,7 @@ func getDaemonSets(namespace string, clientsets *Clientsets, ctx context.Context
 
 	results := make([]Workload, 0, len(daemonsets.Items))
 	for i := range daemonsets.Items {
-		setGroupVersionKindIfEmpty(&daemonsets.Items[i], appsv1.SchemeGroupVersion.WithKind("DaemonSet"))
+		setGroupVersionKindIfEmpty(&daemonsets.Items[i], appsv1.SchemeGroupVersion.WithKind(daemonSetKind))
 		results = append(results, &daemonSet{&daemonsets.Items[i]})
 	}
 
@@ -114,7 +114,7 @@ func (d *daemonSet) Reget(clientsets *Clientsets, ctx context.Context) error {
 		return fmt.Errorf("failed to get cronjob: %w", err)
 	}
 
-	setGroupVersionKindIfEmpty(d.DaemonSet, appsv1.SchemeGroupVersion.WithKind("DaemonSet"))
+	setGroupVersionKindIfEmpty(d.DaemonSet, appsv1.SchemeGroupVersion.WithKind(daemonSetKind))
 
 	return nil
 }

--- a/internal/pkg/scalable/deployments.go
+++ b/internal/pkg/scalable/deployments.go
@@ -22,7 +22,7 @@ func getDeployments(namespace string, clientsets *Clientsets, ctx context.Contex
 
 	results := make([]Workload, 0, len(deployments.Items))
 	for i := range deployments.Items {
-		setGroupVersionKindIfEmpty(&deployments.Items[i], appsv1.SchemeGroupVersion.WithKind("Deployment"))
+		setGroupVersionKindIfEmpty(&deployments.Items[i], appsv1.SchemeGroupVersion.WithKind(deploymentKind))
 		results = append(results, &replicaScaledWorkload{&deployment{&deployments.Items[i]}})
 	}
 
@@ -69,7 +69,7 @@ func (d *deployment) Reget(clientsets *Clientsets, ctx context.Context) error {
 		return fmt.Errorf("failed to get cronjob: %w", err)
 	}
 
-	setGroupVersionKindIfEmpty(d.Deployment, appsv1.SchemeGroupVersion.WithKind("Deployment"))
+	setGroupVersionKindIfEmpty(d.Deployment, appsv1.SchemeGroupVersion.WithKind(deploymentKind))
 
 	return nil
 }

--- a/internal/pkg/scalable/gateways.go
+++ b/internal/pkg/scalable/gateways.go
@@ -30,7 +30,7 @@ func getGateways(namespace string, clientsets *Clientsets, ctx context.Context) 
 		setGroupVersionKindIfEmpty(&gateways.Items[i], schema.GroupVersion{
 			Group:   gatewayv1.GroupVersion.Group,
 			Version: gatewayv1.GroupVersion.Version,
-		}.WithKind("Gateway"))
+		}.WithKind(gatewayKind))
 		results = append(results, &valueScaledWorkload{&gateway{&gateways.Items[i]}})
 	}
 

--- a/internal/pkg/scalable/horizontalpodautoscalers.go
+++ b/internal/pkg/scalable/horizontalpodautoscalers.go
@@ -26,7 +26,7 @@ func getHorizontalPodAutoscalers(namespace string, clientsets *Clientsets, ctx c
 
 	results := make([]Workload, 0, len(hpas.Items))
 	for i := range hpas.Items {
-		setGroupVersionKindIfEmpty(&hpas.Items[i], appsv1.SchemeGroupVersion.WithKind("HorizontalPodAutoscaler"))
+		setGroupVersionKindIfEmpty(&hpas.Items[i], appsv1.SchemeGroupVersion.WithKind(horizontalPodAutoscalerKind))
 		results = append(results, &replicaScaledWorkload{&horizontalPodAutoscaler{&hpas.Items[i]}})
 	}
 
@@ -94,7 +94,7 @@ func (h *horizontalPodAutoscaler) Reget(clientsets *Clientsets, ctx context.Cont
 		return fmt.Errorf("failed to get horizontalpodautoscaler: %w", err)
 	}
 
-	setGroupVersionKindIfEmpty(h.HorizontalPodAutoscaler, appsv1.SchemeGroupVersion.WithKind("HorizontalPodAutoscaler"))
+	setGroupVersionKindIfEmpty(h.HorizontalPodAutoscaler, appsv1.SchemeGroupVersion.WithKind(horizontalPodAutoscalerKind))
 
 	return nil
 }

--- a/internal/pkg/scalable/ingresses.go
+++ b/internal/pkg/scalable/ingresses.go
@@ -26,7 +26,7 @@ func getIngresses(namespace string, clientsets *Clientsets, ctx context.Context)
 
 	results := make([]Workload, 0, len(ingresses.Items))
 	for i := range ingresses.Items {
-		setGroupVersionKindIfEmpty(&ingresses.Items[i], networkingv1.SchemeGroupVersion.WithKind("Ingress"))
+		setGroupVersionKindIfEmpty(&ingresses.Items[i], networkingv1.SchemeGroupVersion.WithKind(ingressKind))
 		results = append(results, &valueScaledWorkload{&ingress{&ingresses.Items[i]}})
 	}
 

--- a/internal/pkg/scalable/jobs.go
+++ b/internal/pkg/scalable/jobs.go
@@ -22,7 +22,7 @@ func getJobs(namespace string, clientsets *Clientsets, ctx context.Context) ([]W
 
 	results := make([]Workload, 0, len(jobs.Items))
 	for i := range jobs.Items {
-		setGroupVersionKindIfEmpty(&jobs.Items[i], batch.SchemeGroupVersion.WithKind("Job"))
+		setGroupVersionKindIfEmpty(&jobs.Items[i], batch.SchemeGroupVersion.WithKind(jobKind))
 		results = append(results, &suspendScaledWorkload{&job{&jobs.Items[i]}})
 	}
 
@@ -71,7 +71,7 @@ func (j *job) Reget(clientsets *Clientsets, ctx context.Context) error {
 		return fmt.Errorf("failed to get job: %w", err)
 	}
 
-	setGroupVersionKindIfEmpty(j.Job, batch.SchemeGroupVersion.WithKind("Job"))
+	setGroupVersionKindIfEmpty(j.Job, batch.SchemeGroupVersion.WithKind(jobKind))
 
 	return nil
 }

--- a/internal/pkg/scalable/kafkabridges.go
+++ b/internal/pkg/scalable/kafkabridges.go
@@ -18,7 +18,7 @@ import (
 
 //nolint:gochecknoglobals // package-level GVK required for unstructured client
 var kafkaBridgeGVK = schema.GroupVersionKind{
-	Group: kafkaStrimziGroup, Version: kafkaStrimziVersion, Kind: "KafkaBridge",
+	Group: kafkaStrimziGroup, Version: kafkaStrimziVersion, Kind: kafkaBridgeKind,
 }
 
 // kafkaBridge wraps an unstructured KafkaBridge CR. The unstructured approach

--- a/internal/pkg/scalable/kafkaconnects.go
+++ b/internal/pkg/scalable/kafkaconnects.go
@@ -18,7 +18,7 @@ import (
 
 //nolint:gochecknoglobals // package-level GVK required for unstructured client
 var kafkaConnectGVK = schema.GroupVersionKind{
-	Group: kafkaStrimziGroup, Version: kafkaStrimziVersion, Kind: "KafkaConnect",
+	Group: kafkaStrimziGroup, Version: kafkaStrimziVersion, Kind: kafkaConnectKind,
 }
 
 // kafkaConnect wraps an unstructured KafkaConnect CR. The unstructured approach

--- a/internal/pkg/scalable/kafkamirrormaker2s.go
+++ b/internal/pkg/scalable/kafkamirrormaker2s.go
@@ -18,7 +18,7 @@ import (
 
 //nolint:gochecknoglobals // package-level GVK required for unstructured client
 var kafkaMirrorMaker2GVK = schema.GroupVersionKind{
-	Group: kafkaStrimziGroup, Version: kafkaStrimziVersion, Kind: "KafkaMirrorMaker2",
+	Group: kafkaStrimziGroup, Version: kafkaStrimziVersion, Kind: kafkaMirrorMaker2Kind,
 }
 
 // kafkaMirrorMaker2 wraps an unstructured KafkaMirrorMaker2 CR. The unstructured approach

--- a/internal/pkg/scalable/poddisruptionbudgets.go
+++ b/internal/pkg/scalable/poddisruptionbudgets.go
@@ -24,7 +24,7 @@ func getPodDisruptionBudgets(namespace string, clientsets *Clientsets, ctx conte
 
 	results := make([]Workload, 0, len(poddisruptionbudgets.Items))
 	for i := range poddisruptionbudgets.Items {
-		setGroupVersionKindIfEmpty(&poddisruptionbudgets.Items[i], policy.SchemeGroupVersion.WithKind("PodDisruptionBudget"))
+		setGroupVersionKindIfEmpty(&poddisruptionbudgets.Items[i], policy.SchemeGroupVersion.WithKind(podDisruptionBudgetKind))
 		results = append(results, &podDisruptionBudget{&poddisruptionbudgets.Items[i]})
 	}
 
@@ -157,7 +157,7 @@ func (p *podDisruptionBudget) Reget(clientsets *Clientsets, ctx context.Context)
 		return fmt.Errorf("failed to get poddisruptionbudget: %w", err)
 	}
 
-	setGroupVersionKindIfEmpty(p.PodDisruptionBudget, policy.SchemeGroupVersion.WithKind("PodDisruptionBudget"))
+	setGroupVersionKindIfEmpty(p.PodDisruptionBudget, policy.SchemeGroupVersion.WithKind(podDisruptionBudgetKind))
 
 	return nil
 }

--- a/internal/pkg/scalable/postgresqls.go
+++ b/internal/pkg/scalable/postgresqls.go
@@ -25,7 +25,7 @@ func getPostgresqls(namespace string, clientsets *Clientsets, ctx context.Contex
 
 	results := make([]Workload, 0, len(postgresqls.Items))
 	for i := range postgresqls.Items {
-		setGroupVersionKindIfEmpty(&postgresqls.Items[i], acidv1.SchemeGroupVersion.WithKind("postgresql"))
+		setGroupVersionKindIfEmpty(&postgresqls.Items[i], acidv1.SchemeGroupVersion.WithKind(postgresqlKind))
 		results = append(results, &replicaScaledWorkload{&postgresql{&postgresqls.Items[i]}})
 	}
 
@@ -53,7 +53,7 @@ func (p *postgresql) Reget(clientsets *Clientsets, ctx context.Context) error {
 		return fmt.Errorf("failed to get postgresql: %w", err)
 	}
 
-	setGroupVersionKindIfEmpty(p.Postgresql, acidv1.SchemeGroupVersion.WithKind("postgresql"))
+	setGroupVersionKindIfEmpty(p.Postgresql, acidv1.SchemeGroupVersion.WithKind(postgresqlKind))
 
 	return nil
 }

--- a/internal/pkg/scalable/prometheuses.go
+++ b/internal/pkg/scalable/prometheuses.go
@@ -22,7 +22,7 @@ func getPrometheuses(namespace string, clientsets *Clientsets, ctx context.Conte
 
 	results := make([]Workload, 0, len(prometheuses.Items))
 	for i := range prometheuses.Items {
-		setGroupVersionKindIfEmpty(&prometheuses.Items[i], monitoringv1.SchemeGroupVersion.WithKind("Prometheus"))
+		setGroupVersionKindIfEmpty(&prometheuses.Items[i], monitoringv1.SchemeGroupVersion.WithKind(prometheusKind))
 		results = append(results, &replicaScaledWorkload{&prometheus{&prometheuses.Items[i]}})
 	}
 
@@ -67,7 +67,7 @@ func (p *prometheus) Reget(clientsets *Clientsets, ctx context.Context) error {
 		return fmt.Errorf("failed to get prometheus: %w", err)
 	}
 
-	setGroupVersionKindIfEmpty(singlePrometheus, monitoringv1.SchemeGroupVersion.WithKind("Prometheus"))
+	setGroupVersionKindIfEmpty(singlePrometheus, monitoringv1.SchemeGroupVersion.WithKind(prometheusKind))
 
 	p.Prometheus = singlePrometheus
 

--- a/internal/pkg/scalable/rollouts.go
+++ b/internal/pkg/scalable/rollouts.go
@@ -22,7 +22,7 @@ func getRollouts(namespace string, clientsets *Clientsets, ctx context.Context) 
 
 	results := make([]Workload, 0, len(rollouts.Items))
 	for i := range rollouts.Items {
-		setGroupVersionKindIfEmpty(&rollouts.Items[i], argov1alpha1.SchemeGroupVersion.WithKind("Rollout"))
+		setGroupVersionKindIfEmpty(&rollouts.Items[i], argov1alpha1.SchemeGroupVersion.WithKind(rolloutKind))
 		results = append(results, &replicaScaledWorkload{&rollout{&rollouts.Items[i]}})
 	}
 
@@ -69,7 +69,7 @@ func (r *rollout) Reget(clientsets *Clientsets, ctx context.Context) error {
 		return fmt.Errorf("failed to get rollout: %w", err)
 	}
 
-	setGroupVersionKindIfEmpty(r.Rollout, argov1alpha1.SchemeGroupVersion.WithKind("Rollout"))
+	setGroupVersionKindIfEmpty(r.Rollout, argov1alpha1.SchemeGroupVersion.WithKind(rolloutKind))
 
 	return nil
 }

--- a/internal/pkg/scalable/scaledobjects.go
+++ b/internal/pkg/scalable/scaledobjects.go
@@ -28,7 +28,7 @@ func getScaledObjects(namespace string, clientsets *Clientsets, ctx context.Cont
 
 	results := make([]Workload, 0, len(scaledobjects.Items))
 	for i := range scaledobjects.Items {
-		setGroupVersionKindIfEmpty(&scaledobjects.Items[i], kedav1alpha1.SchemeGroupVersion.WithKind("ScaledObject"))
+		setGroupVersionKindIfEmpty(&scaledobjects.Items[i], kedav1alpha1.SchemeGroupVersion.WithKind(scaledObjectKind))
 		results = append(results, &replicaScaledWorkload{&scaledObject{&scaledobjects.Items[i]}})
 	}
 
@@ -92,7 +92,7 @@ func (s *scaledObject) Reget(clientsets *Clientsets, ctx context.Context) error 
 		return fmt.Errorf("failed to get scaledObject: %w", err)
 	}
 
-	setGroupVersionKindIfEmpty(s.ScaledObject, kedav1alpha1.SchemeGroupVersion.WithKind("ScaledObject"))
+	setGroupVersionKindIfEmpty(s.ScaledObject, kedav1alpha1.SchemeGroupVersion.WithKind(scaledObjectKind))
 
 	return nil
 }

--- a/internal/pkg/scalable/services.go
+++ b/internal/pkg/scalable/services.go
@@ -45,7 +45,7 @@ func getAWSELBServices(namespace string, clientsets *Clientsets, ctx context.Con
 		svc := &services.Items[i]
 
 		if val, ok := svc.Annotations[AWSLoadBalancerAnnotation]; !ok || !strings.EqualFold(val, "nlb") {
-			setGroupVersionKindIfEmpty(&services.Items[i], corev1.SchemeGroupVersion.WithKind("Service"))
+			setGroupVersionKindIfEmpty(&services.Items[i], corev1.SchemeGroupVersion.WithKind(serviceKind))
 
 			results = append(results, &valueScaledWorkload{&service{svc}})
 		}
@@ -66,7 +66,7 @@ func getAWSNLBServices(namespace string, clientsets *Clientsets, ctx context.Con
 		svc := &services.Items[i]
 
 		if val, ok := svc.Annotations[AWSLoadBalancerAnnotation]; ok && strings.EqualFold(val, "nlb") {
-			setGroupVersionKindIfEmpty(&services.Items[i], corev1.SchemeGroupVersion.WithKind("Service"))
+			setGroupVersionKindIfEmpty(&services.Items[i], corev1.SchemeGroupVersion.WithKind(serviceKind))
 
 			results = append(results, &valueScaledWorkload{&service{svc}})
 		}

--- a/internal/pkg/scalable/stacks.go
+++ b/internal/pkg/scalable/stacks.go
@@ -22,7 +22,7 @@ func getStacks(namespace string, clientsets *Clientsets, ctx context.Context) ([
 
 	results := make([]Workload, 0, len(stacks.Items))
 	for i := range stacks.Items {
-		setGroupVersionKindIfEmpty(&stacks.Items[i], zalandov1.SchemeGroupVersion.WithKind("Stack"))
+		setGroupVersionKindIfEmpty(&stacks.Items[i], zalandov1.SchemeGroupVersion.WithKind(stackKind))
 		results = append(results, &replicaScaledWorkload{&stack{&stacks.Items[i]}})
 	}
 
@@ -69,7 +69,7 @@ func (s *stack) Reget(clientsets *Clientsets, ctx context.Context) error {
 		return fmt.Errorf("failed to get stack: %w", err)
 	}
 
-	setGroupVersionKindIfEmpty(s.Stack, zalandov1.SchemeGroupVersion.WithKind("Stack"))
+	setGroupVersionKindIfEmpty(s.Stack, zalandov1.SchemeGroupVersion.WithKind(stackKind))
 
 	return nil
 }

--- a/internal/pkg/scalable/statefulsets.go
+++ b/internal/pkg/scalable/statefulsets.go
@@ -22,7 +22,7 @@ func getStatefulSets(namespace string, clientsets *Clientsets, ctx context.Conte
 
 	results := make([]Workload, 0, len(statefulsets.Items))
 	for i := range statefulsets.Items {
-		setGroupVersionKindIfEmpty(&statefulsets.Items[i], appsv1.SchemeGroupVersion.WithKind("StatefulSet"))
+		setGroupVersionKindIfEmpty(&statefulsets.Items[i], appsv1.SchemeGroupVersion.WithKind(statefulSetKind))
 		results = append(results, &replicaScaledWorkload{&statefulSet{&statefulsets.Items[i]}})
 	}
 
@@ -69,7 +69,7 @@ func (s *statefulSet) Reget(clientsets *Clientsets, ctx context.Context) error {
 		return fmt.Errorf("failed to get statefulset: %w", err)
 	}
 
-	setGroupVersionKindIfEmpty(s.StatefulSet, appsv1.SchemeGroupVersion.WithKind("StatefulSet"))
+	setGroupVersionKindIfEmpty(s.StatefulSet, appsv1.SchemeGroupVersion.WithKind(statefulSetKind))
 
 	return nil
 }

--- a/internal/pkg/scalable/util.go
+++ b/internal/pkg/scalable/util.go
@@ -15,34 +15,30 @@ import (
 )
 
 const (
-	annotationOriginalReplicas          = "downscaler/original-replicas"
-	defaultKedaScaleTargetRefApiVersion = "apps/v1"
-	defaultKedaScaleTargetRefKind       = "Deployment"
-	kafkaStrimziGroup                   = "kafka.strimzi.io"
-	kafkaStrimziVersion                 = "v1"
+	annotationOriginalReplicas  = "downscaler/original-replicas"
+	deploymentGroupVersion      = "apps/v1"
+	deploymentKind              = "Deployment"
+	autoscalingRunnerSetKind    = "AutoscalingRunnerSet"
+	cronJobKind                 = "CronJob"
+	daemonSetKind               = "DaemonSet"
+	gatewayKind                 = "Gateway"
+	horizontalPodAutoscalerKind = "HorizontalPodAutoscaler"
+	ingressKind                 = "Ingress"
+	jobKind                     = "Job"
+	kafkaStrimziGroup           = "kafka.strimzi.io"
+	kafkaStrimziVersion         = "v1"
+	kafkaBridgeKind             = "KafkaBridge"
+	kafkaConnectKind            = "KafkaConnect"
+	kafkaMirrorMaker2Kind       = "KafkaMirrorMaker2"
+	podDisruptionBudgetKind     = "PodDisruptionBudget"
+	postgresqlKind              = "postgresql" // lowercase for postgresqlKind is intentional
+	prometheusKind              = "Prometheus"
+	rolloutKind                 = "Rollout"
+	scaledObjectKind            = "ScaledObject"
+	serviceKind                 = "Service"
+	stackKind                   = "Stack"
+	statefulSetKind             = "StatefulSet"
 )
-
-var supportedOwnerKinds = map[string]struct{}{
-	"AutoscalingRunnerSet":    {},
-	"CronJob":                 {},
-	"DaemonSet":               {},
-	"Deployment":              {},
-	"Gateway":                 {},
-	"HorizontalPodAutoscaler": {},
-	"Ingress":                 {},
-	"Job":                     {},
-	"KafkaBridge":             {},
-	"KafkaConnect":            {},
-	"KafkaMirrorMaker2":       {},
-	"PodDisruptionBudget":     {},
-	"Postgresql":              {},
-	"Prometheus":              {},
-	"Rollout":                 {},
-	"ScaledObject":            {},
-	"Service":                 {},
-	"Stack":                   {},
-	"StatefulSet":             {},
-}
 
 // FilterExcluded filters the workloads to match the includeLabels, excludedNamespaces and excludedWorkloads.
 func FilterExcluded(
@@ -154,11 +150,11 @@ func getExternallyScaled(workloads []Workload) []workloadIdentifier {
 		kind := scaledobject.Spec.ScaleTargetRef.Kind
 
 		if apiVersion == "" {
-			apiVersion = defaultKedaScaleTargetRefApiVersion
+			apiVersion = deploymentGroupVersion
 		}
 
 		if kind == "" {
-			kind = defaultKedaScaleTargetRefKind
+			kind = deploymentKind
 		}
 
 		apiVersionSlice := strings.SplitN(apiVersion, "/", 2)
@@ -294,8 +290,32 @@ func isWorkloadExcluded(
 	return excludedWorkloads.CheckMatchesAny(workload.GetName())
 }
 
-// isSupportedOwnerKind checks whether the owner kind is supported by the scalable package.
+// isSupportedOwnerKind checks whether the owner kind is supported.
+// The lookup set is built locally (instead of as a package-level global) to avoid
+// mutable package state; construction cost is negligible compared to the owning API calls.
 func isSupportedOwnerKind(kind string) bool {
+	supportedOwnerKinds := map[string]struct{}{
+		autoscalingRunnerSetKind:    {},
+		cronJobKind:                 {},
+		daemonSetKind:               {},
+		deploymentKind:              {},
+		gatewayKind:                 {},
+		horizontalPodAutoscalerKind: {},
+		ingressKind:                 {},
+		jobKind:                     {},
+		kafkaBridgeKind:             {},
+		kafkaConnectKind:            {},
+		kafkaMirrorMaker2Kind:       {},
+		podDisruptionBudgetKind:     {},
+		postgresqlKind:              {},
+		prometheusKind:              {},
+		rolloutKind:                 {},
+		scaledObjectKind:            {},
+		serviceKind:                 {},
+		stackKind:                   {},
+		statefulSetKind:             {},
+	}
+
 	_, supported := supportedOwnerKinds[kind]
 
 	return supported

--- a/internal/pkg/scalable/util.go
+++ b/internal/pkg/scalable/util.go
@@ -22,6 +22,28 @@ const (
 	kafkaStrimziVersion                 = "v1"
 )
 
+var supportedOwnerKinds = map[string]struct{}{
+	"AutoscalingRunnerSet":    {},
+	"CronJob":                 {},
+	"DaemonSet":               {},
+	"Deployment":              {},
+	"Gateway":                 {},
+	"HorizontalPodAutoscaler": {},
+	"Ingress":                 {},
+	"Job":                     {},
+	"KafkaBridge":             {},
+	"KafkaConnect":            {},
+	"KafkaMirrorMaker2":       {},
+	"PodDisruptionBudget":     {},
+	"Postgresql":              {},
+	"Prometheus":              {},
+	"Rollout":                 {},
+	"ScaledObject":            {},
+	"Service":                 {},
+	"Stack":                   {},
+	"StatefulSet":             {},
+}
+
 // FilterExcluded filters the workloads to match the includeLabels, excludedNamespaces and excludedWorkloads.
 func FilterExcluded(
 	workloads []Workload,
@@ -272,12 +294,25 @@ func isWorkloadExcluded(
 	return excludedWorkloads.CheckMatchesAny(workload.GetName())
 }
 
+// isSupportedOwnerKind checks whether the owner kind is supported by the scalable package.
+func isSupportedOwnerKind(kind string) bool {
+	_, supported := supportedOwnerKinds[kind]
+
+	return supported
+}
+
 // isManagedByOwnerReference checks if the workload is managed by an owner reference that is in the includedResources list.
 func isManagedByOwnerReference(workload Workload) bool {
 	for _, ownerReference := range workload.GetOwnerReferences() {
-		if ownerReference.Controller != nil && *ownerReference.Controller {
-			return true
+		if ownerReference.Controller == nil || !*ownerReference.Controller {
+			continue
 		}
+
+		if !isSupportedOwnerKind(ownerReference.Kind) {
+			continue
+		}
+
+		return true
 	}
 
 	return false

--- a/internal/pkg/scalable/util.go
+++ b/internal/pkg/scalable/util.go
@@ -291,8 +291,6 @@ func isWorkloadExcluded(
 }
 
 // isSupportedOwnerKind checks whether the owner kind is supported.
-// The lookup set is built locally (instead of as a package-level global) to avoid
-// mutable package state; construction cost is negligible compared to the owning API calls.
 func isSupportedOwnerKind(kind string) bool {
 	supportedOwnerKinds := map[string]struct{}{
 		autoscalingRunnerSetKind:    {},


### PR DESCRIPTION
## Motivation

As pointed in #517, workloads with ownerReferences are excluded by default even if the ownerReference Kind is not supported by the downscaler.

Example: if a custom CRD creates a `DaemonSet` and `--include-resources=daemonsets,...` is set, The `DaemonSet` created from the custom CRD won't be scaled down or up, it will be simply excluded. This PR changes this behavior: DaemonSet will be excluded only if the custom CRD is actually supported by the downscaler (and therefore could be specified within `--include-resources`)

## Changes

- Refactored the logic: workloads managed by an ownerReference will be excluded only if the ownerReference Kind could be set within  `--include-resources` (when implementing #157, we should remember to add an argument so the user could specify custom ownerReference Kinds alongside the data driven CRDs that are specified within `--include-resources`)

## Tests Done

- Unit Tests