### PR TITLE
Fix/Algorithm Stops When Broken Annotation Is Found

### DIFF
--- a/cmd/kubedownscaler/errors.go
+++ b/cmd/kubedownscaler/errors.go
@@ -11,7 +11,7 @@ func newNamespaceScopeRetrieveError(namespace string) error {
 }
 
 func (n *NamespaceScopeRetrieveError) Error() string {
-	return fmt.Sprintf("failed to get namespace scope for namespace %q", n.namespace)
+	return fmt.Sprintf("failed to parse namespace scope for namespace %q", n.namespace)
 }
 
 type MaxRetriesExceededError struct {

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -209,7 +209,7 @@ func startScanning(
 
 		namespaceScopes, errs := client.GetNamespacesScopes(workloads, ctx)
 		if len(errs) > 0 {
-			handleNamespaceScopeParsingErrors(errs, currentNamespaceToMetrics)
+			handleNamespaceScopeParsingErrors(errs, config, currentNamespaceToMetrics)
 		}
 
 		var waitGroup sync.WaitGroup
@@ -261,16 +261,29 @@ func startScanning(
 	return nil
 }
 
-func handleNamespaceScopeParsingErrors(errs []error, currentNamespaceToMetrics map[string]*metrics.NamespaceMetricsHolder) {
+func handleNamespaceScopeParsingErrors(
+	errs []error,
+	config *runtimeConfiguration,
+	currentNamespaceToMetrics map[string]*metrics.NamespaceMetricsHolder,
+) {
 	for _, err := range errs {
 		slog.Error("failed to get namespace annotations", "error", err)
 
 		var namespaceScopeErr *kubernetes.NamespaceScopeError
-		if errors.As(err, &namespaceScopeErr) {
-			if namespaceMetrics, exists := currentNamespaceToMetrics[namespaceScopeErr.Namespace()]; exists {
-				namespaceMetrics.MarkParsingNamespaceScopeError()
-			}
+		if !errors.As(err, &namespaceScopeErr) {
+			continue
 		}
+
+		namespaceMetrics, metricsErr := getNamespaceMetrics(config, namespaceScopeErr.Namespace(), currentNamespaceToMetrics)
+		if metricsErr != nil {
+			if !errors.Is(metricsErr, ErrMetricsDisabled) {
+				slog.Error("failed to get namespace metrics", "error", metricsErr, "namespace", namespaceScopeErr.Namespace())
+			}
+
+			continue
+		}
+
+		namespaceMetrics.MarkParsingNamespaceScopeError()
 	}
 }
 
@@ -534,6 +547,23 @@ func getWorkloadNamespaceMetrics(
 	}
 
 	return workloadNamespaceMetrics, nil
+}
+
+func getNamespaceMetrics(
+	config *runtimeConfiguration,
+	namespace string,
+	currentNamespaceToMetrics map[string]*metrics.NamespaceMetricsHolder,
+) (*metrics.NamespaceMetricsHolder, error) {
+	if !config.MetricsEnabled {
+		return nil, ErrMetricsDisabled
+	}
+
+	namespaceMetrics, ok := currentNamespaceToMetrics[namespace]
+	if !ok {
+		return nil, NewMetricHolderNotFoundError(namespace)
+	}
+
+	return namespaceMetrics, nil
 }
 
 // newNamespaceToMetrics creates a new map for namespace to metrics holder if metrics are enabled.

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -207,9 +207,9 @@ func startScanning(
 		)
 		slog.Info("scanning over workloads matching filters", "amount", len(workloads))
 
-		namespaceScopes, err := client.GetNamespacesScopes(workloads, ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get namespace annotations: %w", err)
+		namespaceScopes, errs := client.GetNamespacesScopes(workloads, ctx)
+		if len(errs) > 0 {
+			handleNamespaceScopeParsingErrors(errs, currentNamespaceToMetrics)
 		}
 
 		var waitGroup sync.WaitGroup
@@ -259,6 +259,19 @@ func startScanning(
 	}
 
 	return nil
+}
+
+func handleNamespaceScopeParsingErrors(errs []error, currentNamespaceToMetrics map[string]*metrics.NamespaceMetricsHolder) {
+	for _, err := range errs {
+		slog.Error("failed to get namespace annotations", "error", err)
+
+		var namespaceScopeErr *kubernetes.NamespaceScopeError
+		if errors.As(err, &namespaceScopeErr) {
+			if namespaceMetrics, exists := currentNamespaceToMetrics[namespaceScopeErr.Namespace()]; exists {
+				namespaceMetrics.MarkParsingNamespaceScopeError()
+			}
+		}
+	}
 }
 
 // attemptScaling handles retries for scaling a workload in case of conflicts.
@@ -323,6 +336,7 @@ func scanWorkload(
 
 	scopeWorkload := values.NewScope()
 	if err = scopeWorkload.GetScopeFromAnnotations(workload.GetAnnotations(), resourceLogger, ctx); err != nil {
+		workloadNamespaceMetrics.IncrementParsingWorkloadScopeErrorsCount()
 		return fmt.Errorf("failed to parse workload scope from annotations: %w", err)
 	}
 

--- a/cmd/kubedownscaler/main.go
+++ b/cmd/kubedownscaler/main.go
@@ -301,7 +301,7 @@ func attemptScaling(
 		err := scaleWorkload(scaling, workload, scopes, workloadNamespaceMetrics, client, ctx)
 		if err != nil {
 			if !strings.Contains(err.Error(), registry.OptimisticLockErrorMsg) {
-				workloadNamespaceMetrics.IncrementGenericErrorsCount()
+				recordScalingError(err, workloadNamespaceMetrics)
 				return fmt.Errorf("failed to scale workload: %w", err)
 			}
 
@@ -324,6 +324,16 @@ func attemptScaling(
 	slog.Error("failed to scale workload", "attempts", config.MaxRetriesOnConflict+1)
 
 	return newMaxRetriesExceeded(config.MaxRetriesOnConflict)
+}
+
+func recordScalingError(err error, workloadNamespaceMetrics *metrics.NamespaceMetricsHolder) {
+	var scalingInvalidErr *ScalingInvalidError
+	if errors.As(err, &scalingInvalidErr) {
+		workloadNamespaceMetrics.IncrementInvalidScalingValueErrorsCount()
+		return
+	}
+
+	workloadNamespaceMetrics.IncrementGenericErrorsCount()
 }
 
 // scanWorkload runs a scan on the workload, determining the scaling and scaling the workload.
@@ -477,8 +487,6 @@ func scaleWorkload(
 	}
 
 	if scaling == values.ScalingMultiple {
-		workloadNamespaceMetrics.IncrementInvalidScalingValueErrorsCount()
-
 		return newScalingInvalidError(
 			`scaling values matched to multiple states.
 this is the result of a faulty configuration where on a scope there is multiple values with the same priority

--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -47,7 +47,7 @@ type Client interface {
 	// GetNamespacesAsSet gets all namespaces or a specific list of namespace
 	GetNamespacesAsSet() (map[string]struct{}, error)
 	// GetNamespacesScopes gets the namespaces scopes from the namespaces annotations
-	GetNamespacesScopes(workloads []scalable.Workload, ctx context.Context) (map[string]*values.Scope, error)
+	GetNamespacesScopes(workloads []scalable.Workload, ctx context.Context) (map[string]*values.Scope, []error)
 	// GetNamespaceScope gets the namespace scope from its annotations
 	GetNamespaceScope(namespace string, ctx context.Context) (*values.Scope, error)
 	// GetWorkloads gets all workloads of the specified resources for the specified namespaces
@@ -437,7 +437,7 @@ func (c client) GetNamespacesAsSet() (map[string]struct{}, error) {
 }
 
 // GetNamespacesScopes gets the namespaces scopes from the namespaces annotations.
-func (c client) GetNamespacesScopes(workloads []scalable.Workload, ctx context.Context) (map[string]*values.Scope, error) {
+func (c client) GetNamespacesScopes(workloads []scalable.Workload, ctx context.Context) (map[string]*values.Scope, []error) {
 	var waitGroup sync.WaitGroup
 
 	namespaceSet := make(map[string]struct{})
@@ -464,7 +464,7 @@ func (c client) GetNamespacesScopes(workloads []scalable.Workload, ctx context.C
 
 			namespaceScope, err := c.GetNamespaceScope(namespace, ctx)
 			if err != nil {
-				errChan <- fmt.Errorf("failed to get namespace scope for namespace %s: %w", namespace, err)
+				errChan <- newNamespaceScopeError(namespace, err)
 				return
 			}
 
@@ -478,9 +478,11 @@ func (c client) GetNamespacesScopes(workloads []scalable.Workload, ctx context.C
 	close(resultChan)
 	close(errChan)
 
+	var errs []error
+
 	for err := range errChan {
 		if err != nil {
-			return nil, err
+			errs = append(errs, err)
 		}
 	}
 
@@ -490,7 +492,7 @@ func (c client) GetNamespacesScopes(workloads []scalable.Workload, ctx context.C
 		}
 	}
 
-	return namespaceScopes, nil
+	return namespaceScopes, errs
 }
 
 func (c client) GetNamespaceScope(namespace string, ctx context.Context) (*values.Scope, error) {

--- a/internal/api/kubernetes/errors.go
+++ b/internal/api/kubernetes/errors.go
@@ -1,0 +1,32 @@
+package kubernetes
+
+import "fmt"
+
+// NamespaceScopeError identifies a namespace whose scope could not be retrieved or parsed.
+type NamespaceScopeError struct {
+	namespace string
+	err       error
+}
+
+// newNamespaceScopeError creates an error for a namespace scope failure.
+func newNamespaceScopeError(namespace string, err error) error {
+	return &NamespaceScopeError{
+		namespace: namespace,
+		err:       err,
+	}
+}
+
+// Error returns the namespace scope failure message.
+func (e *NamespaceScopeError) Error() string {
+	return fmt.Sprintf("failed to get namespace scope for namespace %q: %v", e.namespace, e.err)
+}
+
+// Unwrap returns the underlying namespace scope error.
+func (e *NamespaceScopeError) Unwrap() error {
+	return e.err
+}
+
+// Namespace returns the namespace whose scope failed.
+func (e *NamespaceScopeError) Namespace() string {
+	return e.namespace
+}

--- a/internal/pkg/metrics/metrics.go
+++ b/internal/pkg/metrics/metrics.go
@@ -8,10 +8,12 @@ import (
 )
 
 const (
-	namespace                 = "namespace"
-	invalidScalingValueErrors = "invalid_scaling_value_errors"
-	conflictErrors            = "conflict_errors"
-	genericErrors             = "generic_errors"
+	namespace                   = "namespace"
+	invalidScalingValueErrors   = "invalid_scaling_value_errors"
+	conflictErrors              = "conflict_errors"
+	genericErrors               = "generic_errors"
+	parsingWorkloadScopeErrors  = "parsing_workload_scope_errors"
+	parsingNamespaceScopeErrors = "parsing_namespace_scope_errors"
 )
 
 type Metrics struct {
@@ -123,6 +125,9 @@ func (m *Metrics) UpdateMetrics(
 		m.scalingErrorWorkloadGauge.WithLabelValues(currentNamespace, invalidScalingValueErrors).Set(metricsRecord.InvalidScalingValueErrors())
 		m.scalingErrorWorkloadGauge.WithLabelValues(currentNamespace, conflictErrors).Set(metricsRecord.ConflictErrors())
 		m.scalingErrorWorkloadGauge.WithLabelValues(currentNamespace, genericErrors).Set(metricsRecord.GenericErrors())
+		m.scalingErrorWorkloadGauge.WithLabelValues(currentNamespace, parsingWorkloadScopeErrors).Set(metricsRecord.ParsingWorkloadScopeErrors())
+		m.scalingErrorWorkloadGauge.WithLabelValues(currentNamespace, parsingNamespaceScopeErrors).Set(
+			metricsRecord.ParsingNamespaceScopeErrors())
 		m.savedMemoryGauge.WithLabelValues(currentNamespace).Set(metricsRecord.SavedMemoryBytes())
 		m.savedCPUGauge.WithLabelValues(currentNamespace).Set(metricsRecord.SavedCPUCores())
 	}

--- a/internal/pkg/metrics/namespaceMetricsHolder.go
+++ b/internal/pkg/metrics/namespaceMetricsHolder.go
@@ -1,101 +1,207 @@
 package metrics
 
+import "sync"
+
 // NamespaceMetricsHolder holds the metrics for a specific namespace.
 type NamespaceMetricsHolder struct {
-	downscaledWorkloads       float64
-	upscaledWorkloads         float64
-	excludedWorkloads         float64
-	invalidScalingValueErrors float64
-	conflictErrors            float64
-	genericErrors             float64
-	savedMemoryBytes          float64
-	savedCPUcores             float64
+	mu sync.RWMutex
+
+	downscaledWorkloads         float64
+	upscaledWorkloads           float64
+	excludedWorkloads           float64
+	invalidScalingValueErrors   float64
+	conflictErrors              float64
+	genericErrors               float64
+	parsingNamespaceScopeErrors float64
+	parsingWorkloadScopeErrors  float64
+	savedMemoryBytes            float64
+	savedCPUcores               float64
 }
 
 func NewNamespaceMetricsHolder() *NamespaceMetricsHolder {
 	return &NamespaceMetricsHolder{
-		downscaledWorkloads:       0,
-		upscaledWorkloads:         0,
-		excludedWorkloads:         0,
-		invalidScalingValueErrors: 0,
-		conflictErrors:            0,
-		genericErrors:             0,
-		savedMemoryBytes:          0,
-		savedCPUcores:             0,
+		downscaledWorkloads:         0,
+		upscaledWorkloads:           0,
+		excludedWorkloads:           0,
+		invalidScalingValueErrors:   0,
+		conflictErrors:              0,
+		genericErrors:               0,
+		parsingNamespaceScopeErrors: 0,
+		parsingWorkloadScopeErrors:  0,
+		savedMemoryBytes:            0,
+		savedCPUcores:               0,
 	}
 }
 
 func (m *NamespaceMetricsHolder) DownscaledWorkloads() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return m.downscaledWorkloads
 }
 
 func (m *NamespaceMetricsHolder) UpscaledWorkloads() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return m.upscaledWorkloads
 }
 
 func (m *NamespaceMetricsHolder) ExcludedWorkloads() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return m.excludedWorkloads
 }
 
 func (m *NamespaceMetricsHolder) InvalidScalingValueErrors() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return m.invalidScalingValueErrors
 }
 
 func (m *NamespaceMetricsHolder) ConflictErrors() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return m.conflictErrors
 }
 
 func (m *NamespaceMetricsHolder) GenericErrors() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return m.genericErrors
 }
 
+func (m *NamespaceMetricsHolder) ParsingWorkloadScopeErrors() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.parsingWorkloadScopeErrors
+}
+
+func (m *NamespaceMetricsHolder) ParsingNamespaceScopeErrors() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.parsingNamespaceScopeErrors
+}
+
 func (m *NamespaceMetricsHolder) SavedMemoryBytes() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return m.savedMemoryBytes
 }
 
 func (m *NamespaceMetricsHolder) SavedCPUCores() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return m.savedCPUcores
 }
 
 func (m *NamespaceMetricsHolder) IncrementDownscaledWorkloadsCount() {
-	if m != nil {
-		m.downscaledWorkloads++
+	if m == nil {
+		return
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.downscaledWorkloads++
 }
 
 func (m *NamespaceMetricsHolder) IncrementUpscaledWorkloadsCount() {
-	if m != nil {
-		m.upscaledWorkloads++
+	if m == nil {
+		return
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.upscaledWorkloads++
 }
 
 func (m *NamespaceMetricsHolder) IncrementExcludedWorkloadsCount() {
-	if m != nil {
-		m.excludedWorkloads++
+	if m == nil {
+		return
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.excludedWorkloads++
 }
 
 func (m *NamespaceMetricsHolder) IncrementInvalidScalingValueErrorsCount() {
-	if m != nil {
-		m.invalidScalingValueErrors++
+	if m == nil {
+		return
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.invalidScalingValueErrors++
 }
 
 func (m *NamespaceMetricsHolder) IncrementConflictErrorsCount() {
-	if m != nil {
-		m.conflictErrors++
+	if m == nil {
+		return
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.conflictErrors++
 }
 
 func (m *NamespaceMetricsHolder) IncrementGenericErrorsCount() {
-	if m != nil {
-		m.genericErrors++
+	if m == nil {
+		return
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.genericErrors++
+}
+
+func (m *NamespaceMetricsHolder) MarkParsingNamespaceScopeError() {
+	if m == nil {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.parsingNamespaceScopeErrors = 1
+}
+
+func (m *NamespaceMetricsHolder) IncrementParsingWorkloadScopeErrorsCount() {
+	if m == nil {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.parsingWorkloadScopeErrors++
 }
 
 func (m *NamespaceMetricsHolder) IncrementSavedResources(savedResources *SavedResources) {
-	if m != nil {
-		m.savedMemoryBytes += savedResources.TotalMemory()
-		m.savedCPUcores += savedResources.TotalCPU()
+	if m == nil {
+		return
 	}
+
+	memoryBytes := savedResources.TotalMemory()
+	cpuCores := savedResources.TotalCPU()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.savedMemoryBytes += memoryBytes
+	m.savedCPUcores += cpuCores
 }


### PR DESCRIPTION
## Motivation

Relaxed the previous constraint that caused the downscaler process to exit when the namespace scope for a particular namespace was malformed. Fixes #520.

## Changes

- Failure to parse the namespace scope for a particular namespace will no longer cause the downscaler process to exit.
- Added `parsingWorkloadScopeErrors` and `parsingNamespaceScopeErrors` types For `scalingErrorWorkloadGauge` metric
- Added locks for read and write operations on metrics to prevent race conditions and unexpected behavior.

## Tests Done

- Unit Tests


